### PR TITLE
Rename toString and export errors

### DIFF
--- a/packages/core/nano/src/index.ts
+++ b/packages/core/nano/src/index.ts
@@ -5,6 +5,7 @@ export {
     compile,
     Delay,
     Delayed,
+    errors,
     Formula,
     isDelayed,
     makeError,

--- a/packages/core/nano/test/nano.spec.ts
+++ b/packages/core/nano/test/nano.spec.ts
@@ -1,5 +1,5 @@
 import { createDiagnosticHandler, createParser, SyntaxKind, ParserSink } from "../src/parser";
-import { compile, CalcValue, CalcObj, CalcFun } from "../src/compiler";
+import { compile, CalcValue, CalcObj, CalcFun, errors } from "../src/compiler";
 import * as assert from "assert";
 import "mocha";
 
@@ -838,10 +838,13 @@ Product(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
         { expression: "4*1*(2+3)*4", expected: 80 },
         { expression: "Foo + Bar", expected: 8 },
         { expression: "IF(Foo * Bar > 10000, 'left', 'right')", expected: "right" },
-        { expression: "4(3,2).toString", expected: "The target of an application must be a calc function." },
-        { expression: "(Sum + 3).toString", expected: "Operator argument must be a primitive." },
+        { expression: "4(3,2).stringify", expected: "The target of an application must be a calc function." },
+        { expression: "(Sum + 3).stringify", expected: "Operator argument must be a primitive." },
         { expression: "42.", expected: 42 },
-        { expression: "42.01", expected: 42.01 }
+        { expression: "42.01", expected: 42.01 },
+        { expression: "1/1", expected: 1 },
+        { expression: "1/0", expected: errors.div0 },
+        { expression: "(1/0).stringify", expected: "#DIV/0!" }
     ]
 
     for (const { expression, expected, errorCount } of parseCases) {


### PR DESCRIPTION
Implementing calc values was a pain because `toString` was clashing with the type `() => string`. Renamed to `stringify`.

Considered `serialize` but I didn't want to imply that the objects could round-trip between strings.

Also export divide by zero errors to unify across clients.