### PR TITLE
Add lambdas

### DIFF
--- a/packages/core/nano/src/ast.ts
+++ b/packages/core/nano/src/ast.ts
@@ -1,0 +1,197 @@
+import { Primitive } from "./core";
+
+import {
+    BinaryOperatorToken,
+    createBooleanErrorHandler,
+    createParser,
+    ParserSink,
+    UnaryOperatorToken,
+} from "./parser";
+
+export const enum NodeKind {
+    Literal,
+    Ident,
+    Field,
+    Paren,
+    Fun,
+    App,
+    Conditional,
+    Dot,
+    BinaryOp,
+    UnaryOp,
+    Missing,
+}
+
+interface LiteralNode {
+    kind: NodeKind.Literal;
+    value: Primitive;
+}
+
+interface IdentNode {
+    kind: NodeKind.Ident;
+    value: string;
+}
+
+interface FieldNode {
+    kind: NodeKind.Field;
+    value: string;
+}
+
+interface ParenNode {
+    kind: NodeKind.Paren;
+    value: FormulaNode;
+}
+
+interface FunNode {
+    kind: NodeKind.Fun;
+    children: FormulaNode[];
+}
+
+interface AppNode {
+    kind: NodeKind.App;
+    children: FormulaNode[];
+}
+
+interface ConditionalNode {
+    kind: NodeKind.Conditional;
+    children: FormulaNode[];
+}
+
+interface DotNode {
+    kind: NodeKind.Dot;
+    operand1: FormulaNode;
+    operand2: FormulaNode;
+}
+
+interface BinaryOpNode {
+    kind: NodeKind.BinaryOp;
+    op: BinaryOperatorToken;
+    operand1: FormulaNode;
+    operand2: FormulaNode;
+}
+
+interface UnaryOpNode {
+    kind: NodeKind.UnaryOp;
+    op: UnaryOperatorToken;
+    operand1: FormulaNode;
+}
+
+interface MissingNode {
+    kind: NodeKind.Missing;
+    value: undefined;
+}
+
+export type FormulaNode =
+    | LiteralNode
+    | IdentNode
+    | FieldNode
+    | ParenNode
+    | FunNode
+    | AppNode
+    | ConditionalNode
+    | DotNode
+    | BinaryOpNode
+    | UnaryOpNode
+    | MissingNode;
+
+
+// Types below are for internal constructors.
+
+type UnaryNode =
+    | NodeKind.Literal
+    | NodeKind.Ident
+    | NodeKind.Field
+    | NodeKind.Paren
+    | NodeKind.Missing;
+
+type BinaryNode =
+    | NodeKind.UnaryOp
+    | NodeKind.Dot
+    | NodeKind.BinaryOp;
+
+type NaryNode =
+    | NodeKind.Fun
+    | NodeKind.App
+    | NodeKind.Conditional;
+
+type NodeOfKind<K extends NodeKind> = Extract<FormulaNode, Record<"kind", K>>;
+type Value<K extends UnaryNode> = NodeOfKind<K> extends { value: infer V } ? V : never;
+type Op<K extends NodeKind> = NodeOfKind<K> extends { op: infer V } ? V : undefined;
+type Operand2<K extends NodeKind> = NodeOfKind<K> extends { operand2: infer V } ? V : undefined;
+
+function createUnaryNode<K extends UnaryNode>(kind: K, value: Value<K>): NodeOfKind<K> {
+    return { kind, value } as any;
+}
+
+function createBinaryNode<K extends BinaryNode>(
+    kind: K,
+    op: Op<K>,
+    operand1: FormulaNode,
+    operand2: Operand2<K>
+): NodeOfKind<K> {
+    return { kind, op, operand1, operand2 } as any;
+}
+
+function createNaryNode<K extends NaryNode>(kind: K, children: FormulaNode[]): NodeOfKind<K> {
+    return { kind, children } as any;
+}
+
+const errorHandler = createBooleanErrorHandler();
+
+const astSink: ParserSink<FormulaNode> = {
+    lit(value: number | string | boolean) {
+        return createUnaryNode(NodeKind.Literal, value);
+    },
+    ident(id: string) {
+        return createUnaryNode(NodeKind.Ident, id);
+    },
+    field(label: string) {
+        return createUnaryNode(NodeKind.Field, label);
+    },
+    paren(expr: FormulaNode) {
+        return createUnaryNode(NodeKind.Paren, expr);
+    },
+    app(head: FormulaNode, args: FormulaNode[], start: number, end: number) {
+        if (head.kind === NodeKind.Ident) {
+            switch (head.value) {
+                case "if":
+                case "IF":
+                    return createNaryNode(NodeKind.Conditional, args);
+                case "fun":
+                case "FUN":
+                    if (args.length === 0) {
+                        errorHandler.onError("Empty function definition", start, end);
+                    }
+                    let error = false;
+                    for (let i = 0; i < args.length - 1; i += 1) {
+                        if (args[i].kind !== NodeKind.Ident) {
+                            error = true;
+                            break;
+                        }
+                    }
+                    if (error) {
+                        // TODO: Better spans;
+                        errorHandler.onError("Illegal function parameter node", start, end);
+                    }
+                    return createNaryNode(NodeKind.Fun, args);
+            }
+        }
+        return createNaryNode(NodeKind.App, [head].concat(args));
+
+    },
+    dot(operand1: FormulaNode, operand2: FormulaNode) {
+        return createBinaryNode(NodeKind.Dot, undefined, operand1, operand2);
+    },
+    binOp(op: BinaryOperatorToken, left: FormulaNode, right: FormulaNode) {
+        return createBinaryNode(NodeKind.BinaryOp, op, left, right);
+    },
+    unaryOp(op: UnaryOperatorToken, expr: FormulaNode) {
+        return createBinaryNode(NodeKind.UnaryOp, op, expr, undefined);
+    },
+    missing(position: number) {
+        errorHandler.onError("missing", position, position);
+        return createUnaryNode(NodeKind.Missing, undefined);
+    }
+};
+
+export const parseFormula = createParser(astSink, errorHandler);

--- a/packages/core/nano/src/compiler.ts
+++ b/packages/core/nano/src/compiler.ts
@@ -1,210 +1,37 @@
-import { Pending } from "./types";
-import { assert } from "./debug";
+import { assert, assertNever } from "./debug";
+
 import {
+    BinaryOperatorToken,
+    createBooleanErrorHandler,
     createParser,
-    ParserErrorHandler,
-    ParserSink,
-    SyntaxKind
+    SyntaxKind,
+    UnaryOperatorToken,
 } from "./parser";
 
+import {
+    binaryOperationsMap,
+    CalcValue,
+    Delayed,
+    ef,
+    Formula,
+    LiftedCore,
+    makeTracer,
+    OpContext,
+    ops,
+    Trace,
+    unaryOperationsMap,
+} from "./core";
 
+import { FormulaNode, NodeKind, parseFormula } from "./ast";
 
-/**
- * Calc Values
- */
+const needsASTCompilation = {};
+const ifIdent = "trace(context.request(host,\"if\"))";
+const funIdent = "trace(context.request(host,\"fun\"))";
+const errorHandler = createBooleanErrorHandler();
 
-export type Primitive = number | string | boolean;
-
-// TODO: Support Completions
-export interface CalcObj<O> {
-    request(origin: O, property: string, ...args: any[]): CalcValue<O> | Pending<CalcValue<O>>;
-}
-
-export interface CalcFun {
-    <O>(trace: Trace, origin: O, args: CalcValue<O>[]): Delayed<CalcValue<O>>;
-}
-
-export type CalcValue<O> = Primitive | CalcObj<O> | CalcFun;
-
-export function makeError(message: string): CalcObj<unknown> {
-    return {
-        request(_, property) {
-            if (property === "stringify") { return message };
-            return this;
-        }
-    };
-}
-
-const requestOnNonObjectError = makeError("The target of a dot-operation must be a calc object.");
-const appOnNonFunctionError = makeError("The target of an application must be a calc function.");
-const functionAsOpArgumentError = makeError("Operator argument must be a primitive.");
-const div0 = makeError("#DIV/0!");
-
-export const errors = {
-    requestOnNonObjectError,
-    appOnNonFunctionError,
-    functionAsOpArgumentError,
-    div0,
-} as const;
-
-/**
- * Delay Effects
- */
-
-declare const $effect: unique symbol;
-export type Delay = { [$effect]: never };
-export type Delayed<T> = T | Delay;
-
-const delay: Delay = {} as any;
-
-export function isDelayed<T>(x: Delayed<T>): x is Delay {
-    return x === delay;
-}
-
-/** 
- * A `Trace` function lifts possibly pending values into `Delayed` and
- * records any pending value.
- */
-export type Trace = <T>(value: T | Pending<T>) => Delayed<T>;
-
-function makeTracer(): [Pending<unknown>[], Trace] {
-    // The trace function is used to catch pending values early and
-    // replace them with a sentinel so that we can use pointer
-    // equality throughout the rest of a calculataion. The
-    // side-effecting here, as opposed to in app/app2, is justified by
-    // pretending that all requests are written in ANF.
-    const data: Pending<unknown>[] = [];
-    const fn: Trace = <T>(value: T | Pending<T>) => {
-        if (typeof value === "object" && (value as any).kind === "Pending") {
-            return data.push(value as Pending<unknown>), delay;
-        }
-        return value as T;
-    }
-    return [data, fn];
-}
-
-/** Lifting of core operations into the `Delayed` S.A.F. */
-interface LiftedCore {
-    req: <O>(trace: Trace, host: O, context: Delayed<CalcValue<O>>, prop: string) => Delayed<CalcValue<O>>;
-    select: <L, R>(cond: Delayed<boolean>, l: () => Delayed<L>, r: () => Delayed<R>) => Delayed<L | R>;
-    app1: <O, A, B>(trace: Trace, host: O, op: <O>(trace: Trace, host: O, expr: A) => B, expr: Delayed<A>) => Delayed<B>;
-    app2: <O, A, B, C>(trace: Trace, host: O, op: <O>(trace: Trace, host: O, l: A, r: B) => C, l: Delayed<A>, r: Delayed<B>) => Delayed<C>;
-    appN: <O>(trace: Trace, host: O, fn: Delayed<CalcValue<O>>, args: Delayed<CalcValue<O>>[]) => Delayed<CalcValue<O>>;
-}
-
-function req<O>(trace: Trace, host: O, context: Delayed<CalcValue<O>>, prop: string): Delayed<CalcValue<O>> {
-    return isDelayed(context) ? delay : typeof context === "object" ? trace(context.request(host, prop)) : requestOnNonObjectError;
-}
-
-function select<L, R>(cond: Delayed<boolean>, l: () => Delayed<L>, r: () => Delayed<R>): Delayed<L | R> {
-    return isDelayed(cond) ? cond : cond ? l() : r();
-}
-
-function app1<O, A, B>(trace: Trace, host: O, op: <O>(trace: Trace, host: O, expr: A) => B, expr: Delayed<A>): Delayed<B> {
-    return isDelayed(expr) ? delay : op(trace, host, expr);
-}
-
-function app2<O, A, B, C>(trace: Trace, host: O, op: <O>(trace: Trace, host: O, l: A, r: B) => C, l: Delayed<A>, r: Delayed<B>): Delayed<C> {
-    return isDelayed(l) || isDelayed(r) ? delay : op(trace, host, l, r);
-}
-
-function appN<O>(trace: Trace, host: O, fn: Delayed<CalcValue<O>>, args: Delayed<CalcValue<O>>[]): Delayed<CalcValue<O>> {
-    if (isDelayed(fn)) { return delay };
-    if (typeof fn !== "function") { return appOnNonFunctionError; }
-    for (let i = 0; i < args.length; i += 1) {
-        if (isDelayed(args[i])) { return delay };
-    }
-    return fn(trace, host, args as CalcValue<O>[]);
-}
-
-const ef: LiftedCore = { req, select, app1, app2, appN };
-
-
-
-/**
- * Operations
- */
-
-const binaryOperationsMap = {
-    [SyntaxKind.PlusToken]: "plus",
-    [SyntaxKind.MinusToken]: "minus",
-    [SyntaxKind.AsteriskToken]: "mult",
-    [SyntaxKind.SlashToken]: "div",
-    [SyntaxKind.EqualsToken]: "eq",
-    [SyntaxKind.LessThanToken]: "lt",
-    [SyntaxKind.GreaterThanToken]: "gt",
-    [SyntaxKind.LessThanEqualsToken]: "lte",
-    [SyntaxKind.GreaterThanEqualsToken]: "gte",
-    [SyntaxKind.NotEqualsToken]: "ne",
-} as const;
-
-const unaryOperationsMap = {
-    [SyntaxKind.MinusToken]: "negate",
-} as const;
-
-type BinaryOperations = typeof binaryOperationsMap;
-type UnaryOperations = typeof unaryOperationsMap;
-type Operations = BinaryOperations[keyof BinaryOperations] | UnaryOperations[keyof UnaryOperations];
-type TinyCalcBinOp = <O>(trace: Trace, host: O, l: CalcValue<O>, r: CalcValue<O>) => Delayed<CalcValue<O>>;
-type TinyCalcUnaryOp = <O>(trace: Trace, host: O, expr: CalcValue<O>) => Delayed<CalcValue<O>>;
-
-function liftBinOp(fn: (l: Primitive, r: Primitive) => Primitive | CalcValue<unknown>): TinyCalcBinOp {
-    return (trace, host, l, r) => {
-        const lAsValue = typeof l === "object" ? trace(l.request(host, "value")) : l;
-        const rAsValue = typeof r === "object" ? trace(r.request(host, "value")) : r;
-        if (typeof lAsValue === "object") { return lAsValue; }
-        if (isDelayed(rAsValue)) { return delay; }
-        if (typeof lAsValue === "function") { return functionAsOpArgumentError; }
-        if (typeof rAsValue === "function") { return functionAsOpArgumentError; }
-        if (typeof rAsValue === "object") { return rAsValue; }
-        return fn(lAsValue, rAsValue);
-    };
-}
-
-function liftUnaryOp(fn: (expr: Primitive) => Primitive): TinyCalcUnaryOp {
-    return (trace, host, expr) => {
-        const exprAsValue = typeof expr === "object" ? trace(expr.request(host, "value")) : expr;
-        if (typeof exprAsValue === "object") { return exprAsValue; }
-        if (typeof exprAsValue === "function") { return functionAsOpArgumentError; }
-        return fn(exprAsValue);
-    };
-}
-
-type OpContext = Record<Operations, TinyCalcBinOp | TinyCalcUnaryOp>;
-const ops: OpContext = {
-    plus: liftBinOp((x: any, y: any) => x + y),
-    minus: liftBinOp((x: any, y: any) => x - y),
-    mult: liftBinOp((x: any, y: any) => x * y),
-    div: liftBinOp((x: any, y: any) => y === 0 ? errors.div0 : x / y),
-    eq: liftBinOp((x: any, y: any) => x === y),
-    lt: liftBinOp((x: any, y: any) => x < y),
-    gt: liftBinOp((x: any, y: any) => x > y),
-    lte: liftBinOp((x: any, y: any) => x <= y),
-    gte: liftBinOp((x: any, y: any) => x >= y),
-    ne: liftBinOp((x: any, y: any) => x !== y),
-    negate: liftUnaryOp((x: any) => -x),
-};
-
-
-
-/**
- * Code-gen
- */
-
-export const createErrorHandler: () => ParserErrorHandler<boolean> = () => {
-    let errors = false;
-    return {
-        errors: () => errors,
-        reset: () => { errors = false; return },
-        onError: () => { errors = true; return }
-    }
-}
-
-const errorHandler = createErrorHandler();
-
-function outputConditional(args: string[], start: number, end: number): string {
+function outputConditional(args: string[]): string {
     if (args.length === 0) {
-        errorHandler.onError("missing conditional arguments", start, end);
+        errorHandler.onError("missing conditional arguments", 0, 0);
         return "";
     }
     const trueExpr = args[1] === undefined ? "true" : args[1];
@@ -212,15 +39,21 @@ function outputConditional(args: string[], start: number, end: number): string {
     return `ef.select(${args[0]},function(){return ${trueExpr};},function(){return ${falseExpr};})`
 }
 
-const simpleSink: ParserSink<string> = {
+const simpleSink = {
     lit(value: number | string | boolean) {
         return JSON.stringify(value);
     },
     ident(id: string) {
-        if (id === "IF") {
-            return id;
+        switch (id) {
+            case "if":
+            case "IF":
+                return ifIdent;
+            case "fun":
+            case "FUN":
+                return funIdent;
+            default:
+                return `trace(context.request(host,${JSON.stringify(id)}))`;
         }
-        return `trace(context.request(host,${JSON.stringify(id)}))`;
     },
     field(label: string) {
         return JSON.stringify(label);
@@ -228,10 +61,12 @@ const simpleSink: ParserSink<string> = {
     paren(expr: string) {
         return `(${expr})`;
     },
-    app(head: string, args: string[], start: number, end: number) {
+    app(head: string, args: string[]) {
         switch (head) {
-            case "IF":
-                return outputConditional(args, start, end);
+            case ifIdent:
+                return outputConditional(args);
+            case funIdent:
+                throw needsASTCompilation;
             default:
                 return `ef.appN(trace,host,${head},[${args}])`;
         }
@@ -239,47 +74,125 @@ const simpleSink: ParserSink<string> = {
     dot(left: string, right: string) {
         return `ef.req(trace,host,${left},${right})`;
     },
-    binOp(op: SyntaxKind, left: string, right: string) {
-        const opStr = "ops." + (binaryOperationsMap as Record<SyntaxKind, string>)[op];
-        assert(opStr !== undefined);
+    binOp(op: BinaryOperatorToken, left: string, right: string) {
+        const opStr = "ops." + binaryOperationsMap[op];
         return `ef.app2(trace,host,${opStr},${left},${right})`;
     },
-    unaryOp(op: SyntaxKind, expr: string) {
+    unaryOp(op: UnaryOperatorToken, expr: string) {
         if (op === SyntaxKind.MinusToken) {
-            const opStr = "ops." + (unaryOperationsMap as Record<SyntaxKind, string>)[op];
-            assert(opStr !== undefined);
+            const opStr = "ops." + unaryOperationsMap[op];
             return `ef.app1(trace,host,${opStr},${expr})`;
         }
         return expr
     },
-    missing(position: number) {
-        errorHandler.onError("missing", position, position);
+    missing() {
+        errorHandler.onError("missing", 0, 0);
         return "";
     }
 };
 
+const makeGensym = () => {
+    let gensym = 0;
+    return () => {
+        return gensym++;
+    }
+};
 
+function compileAST(gensym: () => number, scope: Record<string, string>, f: FormulaNode): string {
+    switch (f.kind) {
+        case NodeKind.Literal:
+            return simpleSink.lit(f.value);
 
-/**
- * Compilation
- */
+        case NodeKind.Ident:
+            if (scope[f.value] !== undefined) {
+                return scope[f.value];
+            }
+            return simpleSink.ident(f.value);
+
+        case NodeKind.Field:
+            return simpleSink.field(f.value);
+
+        case NodeKind.Paren:
+            return simpleSink.paren(compileAST(gensym, scope, f.value));
+
+        case NodeKind.Fun:
+            const children = f.children;
+            assert(children.length > 0);
+            const name = `$args${gensym()}`;
+            const freshScope = { ...scope };
+            for (let i = 0; i < children.length - 1; i += 1) {
+                const ident = children[i];
+                if (ident.kind === NodeKind.Ident) {
+                    freshScope[ident.value] = `${name}[${i}]`;
+                    continue;
+                }
+                return assertNever(ident as never, "FUN arg should be ident");
+            }
+            const body = compileAST(gensym, freshScope, children[children.length - 1]);
+            // TODO: Pass in an actual arity error.
+            return `function(trace, host, ${name}){return ${name}.length>=${children.length - 1}?${body}:"#ARITY!";}`;
+
+        case NodeKind.App:
+            const head = compileAST(gensym, scope, f.children[0]);
+            const args = f.children.slice(1).map(child => compileAST(gensym, scope, child));
+            return simpleSink.app(head, args);
+
+        case NodeKind.Conditional:
+            return outputConditional(f.children.map(child => compileAST(gensym, scope, child)));
+
+        case NodeKind.Dot:
+            return simpleSink.dot(compileAST(gensym, scope, f.operand1), compileAST(gensym, scope, f.operand2));
+
+        case NodeKind.BinaryOp:
+            return simpleSink.binOp(
+                f.op,
+                compileAST(gensym, scope, f.operand1),
+                compileAST(gensym, scope, f.operand2)
+            );
+
+        case NodeKind.UnaryOp:
+            return simpleSink.unaryOp(f.op, compileAST(gensym, scope, f.operand1));
+
+        default:
+            return assertNever(f as never, "Missing should not be compiled");
+    }
+}
 
 type RawFormula = <O>(trace: Trace, host: O, context: CalcValue<O>, ops: OpContext, ef: LiftedCore) => Delayed<CalcValue<O>>;
-
-export type Formula = <O>(host: O, context: CalcValue<O>) => [Pending<unknown>[], Delayed<CalcValue<O>>];
 
 const parse = createParser(simpleSink, errorHandler);
 
 const formula = (raw: RawFormula): Formula => <O>(host: O, context: CalcValue<O>) => {
     const [data, trace] = makeTracer();
     const result = raw(trace, host, context, ops, ef);
-    return [data, result]
-}
+    return [data, result];
+};
 
-export const compile = (text: string) => {
+const quickCompile = (text: string) => {
     const [errors, parsed] = parse(text);
     if (errors) {
         return undefined;
     }
     return formula(new Function("trace", "host", "context", "ops", "ef", `return ${parsed};`) as RawFormula);
+};
+
+const astCompile = (text: string) => {
+    const [errors, ast] = parseFormula(text);
+    if (errors) {
+        return undefined;
+    }
+    const parsed = compileAST(makeGensym(), {}, ast);
+    return formula(new Function("trace", "host", "context", "ops", "ef", `return ${parsed};`) as RawFormula);
+};
+
+export const compile = (text: string) => {
+    try {
+        return quickCompile(text);
+    }
+    catch (e) {
+        if (e === needsASTCompilation) {
+            return astCompile(text);
+        }
+        return assertNever(e as never, "Unexpected error.");
+    }
 };

--- a/packages/core/nano/src/core.ts
+++ b/packages/core/nano/src/core.ts
@@ -100,11 +100,16 @@ function app2<O, A, B, C>(trace: Trace, host: O, op: <O>(trace: Trace, host: O, 
 
 function appN<O>(trace: Trace, host: O, fn: Delayed<CalcValue<O>>, args: Delayed<CalcValue<O>>[]): Delayed<CalcValue<O>> {
     if (isDelayed(fn)) { return delay };
-    if (typeof fn !== "function") { return appOnNonFunctionError; }
+    let target: Delayed<CalcValue<O>> = fn;
+    if (typeof target === "object") {
+        target = trace(target.request(host, "value"));
+    }
+    if (isDelayed(target)) { return delay; }
+    if (typeof target !== "function") { return appOnNonFunctionError; }
     for (let i = 0; i < args.length; i += 1) {
         if (isDelayed(args[i])) { return delay };
     }
-    return fn(trace, host, args as CalcValue<O>[]);
+    return target(trace, host, args as CalcValue<O>[]);
 }
 
 export const ef: LiftedCore = { req, select, app1, app2, appN };

--- a/packages/core/nano/src/core.ts
+++ b/packages/core/nano/src/core.ts
@@ -1,0 +1,174 @@
+import { Pending } from "./types";
+import { SyntaxKind } from "./parser";
+
+export type Primitive = number | string | boolean;
+
+// TODO: Support Completions
+export interface CalcObj<O> {
+    request(origin: O, property: string, ...args: any[]): CalcValue<O> | Pending<CalcValue<O>>;
+}
+
+export interface CalcFun {
+    <O>(trace: Trace, origin: O, args: CalcValue<O>[]): Delayed<CalcValue<O>>;
+}
+
+export type CalcValue<O> = Primitive | CalcObj<O> | CalcFun;
+
+export function makeError(message: string): CalcObj<unknown> {
+    return {
+        request(_, property) {
+            if (property === "stringify") { return message };
+            return this;
+        }
+    };
+}
+
+const requestOnNonObjectError = makeError("The target of a dot-operation must be a calc object.");
+const appOnNonFunctionError = makeError("The target of an application must be a calc function.");
+const functionAsOpArgumentError = makeError("Operator argument must be a primitive.");
+const functionArityError = makeError("#ARITY!");
+const div0 = makeError("#DIV/0!");
+
+export const errors = {
+    requestOnNonObjectError,
+    appOnNonFunctionError,
+    functionAsOpArgumentError,
+    functionArityError,
+    div0,
+} as const;
+
+/**
+ * Delay Effects
+ */
+
+declare const $effect: unique symbol;
+export type Delay = { [$effect]: never };
+export type Delayed<T> = T | Delay;
+
+const delay: Delay = {} as any;
+
+export function isDelayed<T>(x: Delayed<T>): x is Delay {
+    return x === delay;
+}
+
+/** 
+ * A `Trace` function lifts possibly pending values into `Delayed` and
+ * records any pending value.
+ */
+export type Trace = <T>(value: T | Pending<T>) => Delayed<T>;
+
+export function makeTracer(): [Pending<unknown>[], Trace] {
+    // The trace function is used to catch pending values early and
+    // replace them with a sentinel so that we can use pointer
+    // equality throughout the rest of a calculation. The
+    // side-effecting here, as opposed to in app/app2, is justified by
+    // pretending that all requests are written in ANF.
+    const data: Pending<unknown>[] = [];
+    const fn: Trace = <T>(value: T | Pending<T>) => {
+        if (typeof value === "object" && (value as any).kind === "Pending") {
+            return data.push(value as Pending<unknown>), delay;
+        }
+        return value as T;
+    }
+    return [data, fn];
+}
+
+/** Lifting of core operations into the `Delayed` S.A.F. */
+export interface LiftedCore {
+    req: <O>(trace: Trace, host: O, context: Delayed<CalcValue<O>>, prop: string) => Delayed<CalcValue<O>>;
+    select: <L, R>(cond: Delayed<boolean>, l: () => Delayed<L>, r: () => Delayed<R>) => Delayed<L | R>;
+    app1: <O, A, B>(trace: Trace, host: O, op: <O>(trace: Trace, host: O, expr: A) => B, expr: Delayed<A>) => Delayed<B>;
+    app2: <O, A, B, C>(trace: Trace, host: O, op: <O>(trace: Trace, host: O, l: A, r: B) => C, l: Delayed<A>, r: Delayed<B>) => Delayed<C>;
+    appN: <O>(trace: Trace, host: O, fn: Delayed<CalcValue<O>>, args: Delayed<CalcValue<O>>[]) => Delayed<CalcValue<O>>;
+}
+
+function req<O>(trace: Trace, host: O, context: Delayed<CalcValue<O>>, prop: string): Delayed<CalcValue<O>> {
+    return isDelayed(context) ? delay : typeof context === "object" ? trace(context.request(host, prop)) : requestOnNonObjectError;
+}
+
+function select<L, R>(cond: Delayed<boolean>, l: () => Delayed<L>, r: () => Delayed<R>): Delayed<L | R> {
+    return isDelayed(cond) ? cond : cond ? l() : r();
+}
+
+function app1<O, A, B>(trace: Trace, host: O, op: <O>(trace: Trace, host: O, expr: A) => B, expr: Delayed<A>): Delayed<B> {
+    return isDelayed(expr) ? delay : op(trace, host, expr);
+}
+
+function app2<O, A, B, C>(trace: Trace, host: O, op: <O>(trace: Trace, host: O, l: A, r: B) => C, l: Delayed<A>, r: Delayed<B>): Delayed<C> {
+    return isDelayed(l) || isDelayed(r) ? delay : op(trace, host, l, r);
+}
+
+function appN<O>(trace: Trace, host: O, fn: Delayed<CalcValue<O>>, args: Delayed<CalcValue<O>>[]): Delayed<CalcValue<O>> {
+    if (isDelayed(fn)) { return delay };
+    if (typeof fn !== "function") { return appOnNonFunctionError; }
+    for (let i = 0; i < args.length; i += 1) {
+        if (isDelayed(args[i])) { return delay };
+    }
+    return fn(trace, host, args as CalcValue<O>[]);
+}
+
+export const ef: LiftedCore = { req, select, app1, app2, appN };
+
+export const binaryOperationsMap = {
+    [SyntaxKind.PlusToken]: "plus",
+    [SyntaxKind.MinusToken]: "minus",
+    [SyntaxKind.AsteriskToken]: "mult",
+    [SyntaxKind.SlashToken]: "div",
+    [SyntaxKind.EqualsToken]: "eq",
+    [SyntaxKind.LessThanToken]: "lt",
+    [SyntaxKind.GreaterThanToken]: "gt",
+    [SyntaxKind.LessThanEqualsToken]: "lte",
+    [SyntaxKind.GreaterThanEqualsToken]: "gte",
+    [SyntaxKind.NotEqualsToken]: "ne",
+} as const;
+
+export const unaryOperationsMap = {
+    [SyntaxKind.MinusToken]: "negate",
+} as const;
+
+type BinaryOperations = typeof binaryOperationsMap;
+type UnaryOperations = typeof unaryOperationsMap;
+type Operations = BinaryOperations[keyof BinaryOperations] | UnaryOperations[keyof UnaryOperations];
+type TinyCalcBinOp = <O>(trace: Trace, host: O, l: CalcValue<O>, r: CalcValue<O>) => Delayed<CalcValue<O>>;
+type TinyCalcUnaryOp = <O>(trace: Trace, host: O, expr: CalcValue<O>) => Delayed<CalcValue<O>>;
+
+function liftBinOp(fn: (l: Primitive, r: Primitive) => CalcValue<unknown>): TinyCalcBinOp {
+    return (trace, host, l, r) => {
+        const lAsValue = typeof l === "object" ? trace(l.request(host, "value")) : l;
+        const rAsValue = typeof r === "object" ? trace(r.request(host, "value")) : r;
+        if (typeof lAsValue === "object") { return lAsValue; }
+        if (isDelayed(rAsValue)) { return delay; }
+        if (typeof lAsValue === "function") { return functionAsOpArgumentError; }
+        if (typeof rAsValue === "function") { return functionAsOpArgumentError; }
+        if (typeof rAsValue === "object") { return rAsValue; }
+        return fn(lAsValue, rAsValue);
+    };
+}
+
+function liftUnaryOp(fn: (expr: Primitive) => Primitive): TinyCalcUnaryOp {
+    return (trace, host, expr) => {
+        const exprAsValue = typeof expr === "object" ? trace(expr.request(host, "value")) : expr;
+        if (typeof exprAsValue === "object") { return exprAsValue; }
+        if (typeof exprAsValue === "function") { return functionAsOpArgumentError; }
+        return fn(exprAsValue);
+    };
+}
+
+export type OpContext = Record<Operations, TinyCalcBinOp | TinyCalcUnaryOp>;
+
+export const ops: OpContext = {
+    plus: liftBinOp((x: any, y: any) => x + y),
+    minus: liftBinOp((x: any, y: any) => x - y),
+    mult: liftBinOp((x: any, y: any) => x * y),
+    div: liftBinOp((x: any, y: any) => y === 0 ? errors.div0 : x / y),
+    eq: liftBinOp((x: any, y: any) => x === y),
+    lt: liftBinOp((x: any, y: any) => x < y),
+    gt: liftBinOp((x: any, y: any) => x > y),
+    lte: liftBinOp((x: any, y: any) => x <= y),
+    gte: liftBinOp((x: any, y: any) => x >= y),
+    ne: liftBinOp((x: any, y: any) => x !== y),
+    negate: liftUnaryOp((x: any) => -x),
+};
+
+export type Formula = <O>(host: O, context: CalcValue<O>) => [Pending<unknown>[], Delayed<CalcValue<O>>];
+

--- a/packages/core/nano/src/index.ts
+++ b/packages/core/nano/src/index.ts
@@ -2,7 +2,6 @@ export {
     CalcFun,
     CalcObj,
     CalcValue,
-    compile,
     Delay,
     Delayed,
     errors,
@@ -11,6 +10,10 @@ export {
     makeError,
     Primitive,
     Trace
+} from "./core";
+
+export {
+    compile,
 } from "./compiler";
 
 export {

--- a/packages/core/nano/test/nano.spec.ts
+++ b/packages/core/nano/test/nano.spec.ts
@@ -66,9 +66,7 @@ describe("nano", () => {
         it(`Eval: ${expression}`, () => {
             const f = compile(expression);
             assert.notEqual(f, undefined);
-            console.time(expression);
             const [pending, actual] = f!(undefined, testContext);
-            console.timeEnd(expression);
             assert.deepEqual(pending, []);
             assert.strictEqual(actual, expected);
         });

--- a/packages/core/nano/test/nano.spec.ts
+++ b/packages/core/nano/test/nano.spec.ts
@@ -1,5 +1,6 @@
-import { createDiagnosticHandler, createParser, SyntaxKind, ParserSink } from "../src/parser";
-import { compile, CalcValue, CalcObj, CalcFun, errors } from "../src/compiler";
+import { createDiagnosticErrorHandler, createParser, SyntaxKind, ParserSink } from "../src/parser";
+import { compile } from "../src/compiler";
+import { CalcValue, CalcObj, CalcFun, errors } from "../src/core";
 import * as assert from "assert";
 import "mocha";
 
@@ -33,7 +34,7 @@ const astSink: ParserSink<object> = {
     }
 };
 
-export const astParse = createParser(astSink, createDiagnosticHandler());
+export const astParse = createParser(astSink, createDiagnosticErrorHandler());
 
 const sum: CalcFun = <O>(_trace: any, _host: O, args: any[]) => args.reduce((prev, now) => prev + now, 0);
 const prod: CalcFun = <O>(_trace: any, _host: O, args: any[]) => args.reduce((prev, now) => prev * now, 1);
@@ -65,9 +66,18 @@ describe("nano", () => {
         it(`Eval: ${expression}`, () => {
             const f = compile(expression);
             assert.notEqual(f, undefined);
+            console.time(expression);
             const [pending, actual] = f!(undefined, testContext);
+            console.timeEnd(expression);
             assert.deepEqual(pending, []);
             assert.strictEqual(actual, expected);
+        });
+    }
+
+    function compilationFailureTest(expression: string) {
+        it(`Eval: ${expression}`, () => {
+            const f = compile(expression);
+            assert.strictEqual(f, undefined);
         });
     }
 
@@ -810,7 +820,7 @@ describe("nano", () => {
             },
             errorCount: 0
         },
-    ]
+    ];
 
     const evalCases = [
         { expression: "----4", expected: 4 },
@@ -827,6 +837,9 @@ Product(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
 Sum(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)+
 Product(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1)`, expected: 259
         },
+        { expression: "IF", expected: 0 },
+        { expression: "FUN", expected: 0 },
+        { expression: "IF(true)", expected: true },
         { expression: "IF(Foo > 2, Foo + Bar, Bar * Foo)", expected: 8 },
         { expression: "1.3333 + 2.2222", expected: 3.5555 },
         { expression: "1 + 2    + 3 + 4 =   10 - 10 + 10", expected: true },
@@ -844,8 +857,22 @@ Product(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
         { expression: "42.01", expected: 42.01 },
         { expression: "1/1", expected: 1 },
         { expression: "1/0", expected: errors.div0 },
-        { expression: "(1/0).stringify", expected: "#DIV/0!" }
-    ]
+        { expression: "(1/0).stringify", expected: "#DIV/0!" },
+        { expression: "FUN(42)()", expected: 42 },
+        { expression: "FUN(x, y, x + y)(1)", expected: "#ARITY!" },
+        { expression: "FUN(x, y, z, x + y + z)(1, 2, 3) + FUN(x, y, z, x + y + z)(4, 5, 6) + FUN(x, y, z, x + y + z)(7, 8, 9) + FUN(x, y, z, x + y + z)(10, 11, 12)", expected: 78 },
+        { expression: "FUN(f, f(1, 2, 3) + f(4, 5, 6) + f(7, 8, 9) + f(10, 11, 12))(FUN(x, y, z, x + y + z))", expected: 78 },
+        { expression: "FUN(x, y, z, x + FUN(x, x*x)(y) + z)(2, 3, 4)", expected: 15 },
+        { expression: "FUN(g, f, FUN(x, g(f(x))))(FUN(x, x + 1), FUN(x, x - 1))(10)=10", expected: true }
+    ];
+
+    const compilationFailureCases = [
+        { expression: "4+" },
+        { expression: "+" },
+        { expression: "FUN()" },
+        { expression: "FUN(4,4,4+4)" },
+        { expression: "IF()" },
+    ];
 
     for (const { expression, expected, errorCount } of parseCases) {
         parseTest(expression, expected, errorCount);
@@ -853,5 +880,9 @@ Product(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
 
     for (const { expression, expected } of evalCases) {
         evalTest(expression, expected);
+    }
+
+    for (const { expression } of compilationFailureCases) {
+        compilationFailureTest(expression);
     }
 });

--- a/packages/core/nano/test/nano.spec.ts
+++ b/packages/core/nano/test/nano.spec.ts
@@ -46,6 +46,7 @@ const testContext: CalcObj<undefined> = {
             case "Bar": return 5;
             case "Baz": return { kind: "Pending" };
             case "Qux": return { kind: "Pending" };
+            case "A1": return { request(_, prop) { return prop === "value" ? sum : 0 } };
             case "Sum": return sum;
             case "Product": return prod;
             default: return 0;
@@ -857,6 +858,7 @@ Product(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
         { expression: "1/0", expected: errors.div0 },
         { expression: "(1/0).stringify", expected: "#DIV/0!" },
         { expression: "FUN(42)()", expected: 42 },
+        { expression: "A1(1, 2, 3, FUN(42)())", expected: 48 },
         { expression: "FUN(x, y, x + y)(1)", expected: "#ARITY!" },
         { expression: "FUN(x, y, z, x + y + z)(1, 2, 3) + FUN(x, y, z, x + y + z)(4, 5, 6) + FUN(x, y, z, x + y + z)(7, 8, 9) + FUN(x, y, z, x + y + z)(10, 11, 12)", expected: 78 },
         { expression: "FUN(f, f(1, 2, 3) + f(4, 5, 6) + f(7, 8, 9) + f(10, 11, 12))(FUN(x, y, z, x + y + z))", expected: 78 },

--- a/packages/core/nano/test/nano.spec.ts
+++ b/packages/core/nano/test/nano.spec.ts
@@ -73,7 +73,7 @@ describe("nano", () => {
     }
 
     function compilationFailureTest(expression: string) {
-        it(`Eval: ${expression}`, () => {
+        it(`Compilation Failure: ${expression}`, () => {
             const f = compile(expression);
             assert.strictEqual(f, undefined);
         });


### PR DESCRIPTION
Add lambdas abstractions.

If we encounter an abstraction while compiling using the straight-to-string sink we bail and parse using an AST. The reason is because straight-to-string compilation is strictly bottom-up, but for function compilation we need some top-down processing to determine which identifiers denote bound variables. Is there a better way to solve this?

I've moved the runtime implementations into `core.ts`.

Fixes #22 