### PR TITLE
Change CalcFun type to support lambdas

### DIFF
--- a/packages/core/nano/src/core.ts
+++ b/packages/core/nano/src/core.ts
@@ -8,11 +8,11 @@ export interface CalcObj<O> {
     request(origin: O, property: string, ...args: any[]): CalcValue<O> | Pending<CalcValue<O>>;
 }
 
-export interface CalcFun {
-    <O>(trace: Trace, origin: O, args: CalcValue<O>[]): Delayed<CalcValue<O>>;
+export interface CalcFun<O = unknown> {
+    <T extends O>(trace: Trace, origin: T, args: CalcValue<T>[]): Delayed<CalcValue<T>>;
 }
 
-export type CalcValue<O> = Primitive | CalcObj<O> | CalcFun;
+export type CalcValue<O> = Primitive | CalcObj<O> | CalcFun<O>;
 
 export function makeError(message: string): CalcObj<unknown> {
     return {


### PR DESCRIPTION
This PR changes the type of `CalcFun` slightly in light of the addition of lambda abstractions.

Previously the only functions were those defined explicitly. In this case all calc values accessible to the implementation of the function were provided by the arguments, and therefore bound by the generic parameter of `CalcFun`. This does not hold for lambdas. In the case of lambdas the body of the function may also have access to the original `context` CalcValue that is parameterised by a different origin.

As a concrete example. Define a lambda in the grid; the context calc value will be something like `CalcValue<GridCoord>`. It would not be safe to call the lambda at any other origin type `O` because that origin might be passed to the context that expects `GridCoord`. 

To fix this we constrain the origin parameter of calc fun by the origin of the containing calc value. If a lambda is defined in the grid and exported it must be called with an origin that satisfies the initial context of the defined lamba - `GridCoord`.