### PR TITLE
Rename request to read

### DIFF
--- a/packages/core/nano/src/compiler.ts
+++ b/packages/core/nano/src/compiler.ts
@@ -25,8 +25,8 @@ import {
 import { FormulaNode, NodeKind, parseFormula } from "./ast";
 
 const needsASTCompilation = {};
-const ifIdent = "trace(context.request(host,\"if\"))";
-const funIdent = "trace(context.request(host,\"fun\"))";
+const ifIdent = "trace(context.read(\"if\", host))";
+const funIdent = "trace(context.read(\"fun\", host))";
 const errorHandler = createBooleanErrorHandler();
 
 function outputConditional(args: string[]): string {
@@ -52,7 +52,7 @@ const simpleSink = {
             case "FUN":
                 return funIdent;
             default:
-                return `trace(context.request(host,${JSON.stringify(id)}))`;
+                return `trace(context.read(${JSON.stringify(id)},host))`;
         }
     },
     field(label: string) {
@@ -72,7 +72,7 @@ const simpleSink = {
         }
     },
     dot(left: string, right: string) {
-        return `ef.req(trace,host,${left},${right})`;
+        return `ef.read(trace,host,${left},${right})`;
     },
     binOp(op: BinaryOperatorToken, left: string, right: string) {
         const opStr = "ops." + binaryOperationsMap[op];

--- a/packages/core/nano/test/nano.spec.ts
+++ b/packages/core/nano/test/nano.spec.ts
@@ -40,13 +40,13 @@ const sum: CalcFun = <O>(_trace: any, _host: O, args: any[]) => args.reduce((pre
 const prod: CalcFun = <O>(_trace: any, _host: O, args: any[]) => args.reduce((prev, now) => prev * now, 1);
 
 const testContext: CalcObj<undefined> = {
-    request: (_origin: undefined, property: string) => {
+    read: (property: string) => {
         switch (property) {
             case "Foo": return 3;
             case "Bar": return 5;
             case "Baz": return { kind: "Pending" };
             case "Qux": return { kind: "Pending" };
-            case "A1": return { request(_, prop) { return prop === "value" ? sum : 0 } };
+            case "A1": return { read(prop) { return prop === "value" ? sum : 0 } };
             case "Sum": return sum;
             case "Product": return prod;
             default: return 0;

--- a/packages/test/example/src/types.ts
+++ b/packages/test/example/src/types.ts
@@ -56,7 +56,7 @@ function createPending(v: Pending<Value>): Pending<CalcValue<FormulaHost>> {
 function createCalcValue(v: Producer): CalcObj<FormulaHost> {
     const cache: Record<string, CalcValue<FormulaHost>> = {};
     return {
-        request: (consumer: IConsumer<Record<string, Value>>, prop: string) => {
+        read: (prop: string, consumer: IConsumer<Record<string, Value>>) => {
             if (cache[prop] !== undefined) {
                 return cache[prop];
             }


### PR DESCRIPTION
Fixes #23 

This is a breaking change for some clients of tiny-calc and any implementers of `CalcObj` will need to be fixed up accordingly. 