### PR TITLE
Implement produce(..) to promote JSON graphs to IProducer<T>

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3,7 +3,7 @@ dependencies:
   '@rush-temp/nano': 'file:projects/nano.tgz'
   '@types/benchmark': 1.0.31
   '@types/mocha': 5.2.7
-  '@types/node': 8.10.51
+  '@types/node': 10.14.18
   benchmark: 2.1.4
   mocha: 6.2.0
   rimraf: 2.6.3
@@ -19,10 +19,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
-  /@types/node/8.10.51:
+  /@types/node/10.14.18:
     dev: false
     resolution:
-      integrity: sha512-cArrlJp3Yv6IyFT/DYe+rlO8o3SIHraALbBW/+CcCYW/a9QucpLI+n2p4sRxAvl2O35TiecpX2heSZtJjvEO+Q==
+      integrity: sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ==
   /ansi-colors/3.2.3:
     dev: false
     engines:
@@ -929,20 +929,21 @@ packages:
       integrity: sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==
   'file:projects/example.tgz':
     dependencies:
+      '@types/node': 10.14.18
       rimraf: 2.6.3
       ts-node: 8.3.0_typescript@3.5.3
       typescript: 3.5.3
     dev: false
     name: '@rush-temp/example'
     resolution:
-      integrity: sha512-wjxYy/PpiFXyELD+bLA7ceeAF6W3lNcdJVY1Rxhl/QfHFXPHUOpGv7pLxf1jyseevAXsE+luUfldKXJxcuwqNA==
+      integrity: sha512-B6y7YXfCU+/YdkNNeQBG5gFkG59HRQlaEUZndIPMfijb/BjfnIticUmhggF9PgwJgdjv0Gy4lztS0b58ydxbtw==
       tarball: 'file:projects/example.tgz'
     version: 0.0.0
   'file:projects/nano.tgz':
     dependencies:
       '@types/benchmark': 1.0.31
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.51
+      '@types/node': 10.14.18
       benchmark: 2.1.4
       mocha: 6.2.0
       rimraf: 2.6.3
@@ -951,15 +952,16 @@ packages:
     dev: false
     name: '@rush-temp/nano'
     resolution:
-      integrity: sha512-T4uqNz5tTH0hsVQ9mg8VZfoBgb6t2zAdCstks1z9kCbDuS0zMr41ctIBb54SZL2zF5cT7GdIWaAMnPbbRdSoBg==
+      integrity: sha512-sat3syQ7AfASP2dRgwKz2IWvaopJggjYx6ctLSzIAh081NpBiD110bD4nXdNOCXzyWmT+IFVATCh3n7/X4k5Ow==
       tarball: 'file:projects/nano.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
   '@rush-temp/example': 'file:./projects/example.tgz'
   '@rush-temp/nano': 'file:./projects/nano.tgz'
   '@types/benchmark': ^1.0.31
   '@types/mocha': ^5.2.6
-  '@types/node': ^8.10.46
+  '@types/node': ^10.0.0
   benchmark: ^2.1.4
   mocha: ^6.1.4
   rimraf: ^2.6.3

--- a/packages/core/nano/bench/index.ts
+++ b/packages/core/nano/bench/index.ts
@@ -1,9 +1,9 @@
 import { Suite } from "benchmark";
-import { runSuite, consume } from "./util";
+import { consume, runSuite, runSuites } from "./util";
 import { compile } from "../src/compiler";
-import { suite as jsonSuite } from "./json";
+import { suites as jsonSuites } from "./json";
 
-runSuite(jsonSuite);
+runSuites(jsonSuites);
 
 const formulas = [
     "0",

--- a/packages/core/nano/bench/index.ts
+++ b/packages/core/nano/bench/index.ts
@@ -1,6 +1,9 @@
 import { Suite } from "benchmark";
 import { runSuite, consume } from "./util";
 import { compile } from "../src/compiler";
+import { suite as jsonSuite } from "./json";
+
+runSuite(jsonSuite);
 
 const formulas = [
     "0",

--- a/packages/core/nano/bench/json.ts
+++ b/packages/core/nano/bench/json.ts
@@ -1,14 +1,42 @@
 import { Suite } from "benchmark";
 import { consume } from "./util";
 import { produce } from "../src/produce";
-import { NullConsumer } from "../test/util";
+import { nullConsumer } from "../test/util";
 
-const array = new Array<number>(10000).fill(0).map(() => Math.random());
-const producer = produce(array.slice());
-const consumer = new NullConsumer();
-const reader = producer.openVector(undefined as any);
+export const suites = [];
 
-export const suite = new Suite("Native Array vs. IReader");
-suite.add(`array`, () => { let sum = 0; for (let i = array.length - 1; i >= 0; i--) { sum += array[i]; } return consume(sum); });
-suite.add(`open().read()`, () => { let sum = 0; for (let i = reader.length - 1; i >= 0; i--) { sum += producer.open(consumer).read(i) as number; }; return consume(sum); });
-suite.add(`cached reader`, () => { let sum = 0; for (let i = reader.length - 1; i >= 0; i--) { sum += reader.read(i) as number; }; return consume(sum); });
+{
+    const array = new Array<number>(10000).fill(0).map(() => Math.random());
+    const producer = produce(array.slice());
+    const reader = producer.openVector(nullConsumer);
+    
+    const suite = new Suite("Native Array vs. IReader");
+    
+    suite.add(`array`,
+        () => {
+            let sum = 0;
+            for (let i = array.length - 1; i >= 0; i--) {
+                sum += array[i];
+            }
+            return consume(sum);
+        });
+    
+    suite.add(`openVector().read()`,
+        () => {
+            let sum = 0;
+            for (let i = reader.length - 1; i >= 0; i--) {
+                sum += producer.openVector(nullConsumer).read(i);
+            };
+            return consume(sum);
+        });
+    
+    suite.add(`cached reader`, () => {
+        let sum = 0;
+        for (let i = reader.length - 1; i >= 0; i--) {
+            sum += reader.read(i);
+        };
+        return consume(sum);
+    });
+    
+    suites.push(suite);
+}

--- a/packages/core/nano/bench/json.ts
+++ b/packages/core/nano/bench/json.ts
@@ -1,0 +1,14 @@
+import { Suite } from "benchmark";
+import { consume } from "./util";
+import { produce } from "../src/produce";
+import { NullConsumer } from "../test/util";
+
+const array = new Array<number>(10000).fill(0).map(() => Math.random());
+const producer = produce(array.slice());
+const consumer = new NullConsumer();
+const reader = producer.openVector(undefined as any);
+
+export const suite = new Suite("Native Array vs. IReader");
+suite.add(`array`, () => { let sum = 0; for (let i = array.length - 1; i >= 0; i--) { sum += array[i]; } return consume(sum); });
+suite.add(`open().read()`, () => { let sum = 0; for (let i = reader.length - 1; i >= 0; i--) { sum += producer.open(consumer).read(i) as number; }; return consume(sum); });
+suite.add(`cached reader`, () => { let sum = 0; for (let i = reader.length - 1; i >= 0; i--) { sum += reader.read(i) as number; }; return consume(sum); });

--- a/packages/core/nano/bench/util.ts
+++ b/packages/core/nano/bench/util.ts
@@ -39,3 +39,9 @@ export function runSuite(suite: Suite) {
         })
         .run();
 }
+
+export function runSuites(suites: Iterable<Suite>) {
+    for (const suite of suites) {
+        runSuite(suite);
+    }
+}

--- a/packages/core/nano/package.json
+++ b/packages/core/nano/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@types/benchmark": "^1.0.31",
     "@types/mocha": "^5.2.6",
-    "@types/node": "^8.10.46",
+    "@types/node": "^10.0.0",
     "benchmark": "^2.1.4",
     "mocha": "^6.1.4",
     "rimraf": "^2.6.3",

--- a/packages/core/nano/src/index.ts
+++ b/packages/core/nano/src/index.ts
@@ -26,3 +26,7 @@ export {
     IMatrixConsumer,
     IMatrixProducer
 } from "./types";
+
+export {
+    produce
+} from "./produce";

--- a/packages/core/nano/src/produce.ts
+++ b/packages/core/nano/src/produce.ts
@@ -1,0 +1,36 @@
+import { IVectorProducer, IProducer } from "./types";
+
+const unitFn = () => {};
+
+const props = {
+    open: { value: function() { return this; }},
+    removeConsumer: { value: unitFn },
+    read: { value: function(key: PropertyKey) { return (this as any)[key]; }},
+}
+
+const vectorProps = {
+    ...props,
+    openVector: { value: function() { return this; }},
+    removeVectorConsumer: { value: unitFn },
+}
+
+export function produce<T>(subject: ArrayLike<T>): IProducer<ArrayLike<T>> & IVectorProducer<T>;
+export function produce<T extends Readonly<object>>(subject: T): IProducer<T>;
+export function produce<T extends Readonly<object>>(subject: T): IProducer<T> {
+    if ((subject as any).removeConsumer === unitFn) {
+        return subject as any;
+    }
+
+    Object.defineProperties(subject,
+        Array.isArray(subject)
+            ? vectorProps
+            : props);
+
+    for (const value of Object.values(subject)) {
+        if (typeof value === "object" && value) {
+            produce(value);
+        }
+    }
+
+    return subject as any;
+}

--- a/packages/core/nano/src/types.ts
+++ b/packages/core/nano/src/types.ts
@@ -53,6 +53,11 @@ export interface IVectorConsumer<T> {
     itemsChanged(index: number, numRemoved: number, itemInserted: T[], producer: IVectorProducer<T>): void;
 }
 
+export interface IVectorReader<T> {
+    readonly length: number;
+    read(index: number): T;
+}
+
 /** Provides more efficient access to 1D data for vector-aware consumers. */
 export interface IVectorProducer<T> {
     /**
@@ -61,10 +66,7 @@ export interface IVectorProducer<T> {
      */
     removeVectorConsumer(consumer: IVectorConsumer<T>): void;
 
-    openVector(consumer: IVectorConsumer<T>): {
-        readonly length: T;
-        read(index: number): T;
-    }
+    openVector(consumer: IVectorConsumer<T>): IVectorReader<T>;
 }
 
 export interface IMatrixConsumer<T> {
@@ -78,7 +80,13 @@ export interface IMatrixConsumer<T> {
     cellsReplaced(row: number, col: number, numRows: number, numCols: number, values: T[], producer: IMatrixProducer<T>): void;
 }
 
-/** Provides more efficient access to 2D data for vector-aware consumers. */
+export interface IMatrixReader<T> {
+    readonly numRows: number;
+    readonly numCols: number;
+    read(row: number, col: number): T;
+}
+
+/** Provides more efficient access to 2D data for matrix-aware consumers. */
 export interface IMatrixProducer<T> {
     /**
      * Unsubscribes a consumer from this producer.
@@ -86,9 +94,5 @@ export interface IMatrixProducer<T> {
      */
     removeMatrixConsumer(consumer: IMatrixConsumer<T>): void;
 
-    openMatrix(consumer: IMatrixConsumer<T>): {
-        readonly numRows: number;
-        readonly numCols: number;
-        read(row: number, col: number): T;
-    }
+    openMatrix(consumer: IMatrixConsumer<T>): IMatrixReader<T>;
 }

--- a/packages/core/nano/test/produce.spec.ts
+++ b/packages/core/nano/test/produce.spec.ts
@@ -1,31 +1,56 @@
 import "mocha";
 import { strict as assert } from "assert";
 import { produce } from "../src/produce";
-import { NullConsumer } from "./util";
+import { nullConsumer } from "./util";
+import { IProducer } from "../src/types";
 
 describe("produce()", () => {
     describe("object", () => {
         it("supports open(), but not openVector()", () => {
             const p = produce({ a: 1 });
             assert.equal("openVector" in p, false);
-            const r = p.open(new NullConsumer());
+            const r = p.open(nullConsumer);
             assert.equal(r.read("a"), 1);
             assert.equal(r.read("b" as any), undefined);
+        });
+
+        it("handles cycles", () => {
+            const root = { child: undefined };
+            const child = { parent: root };
+            root.child = child as any;
+
+            const p = produce(root);
+            const r = p.open(nullConsumer);
+            const childProducer = r.read("child") as unknown as IProducer<any>;
+            const childReader = childProducer.open(nullConsumer);
+            assert.equal(childReader.read("parent"), p);
         });
     })
 
     describe("array", () => {
         it("supports open() and openVector()", () => {
             const p = produce([0]);
-            const r = p.open(new NullConsumer());
+            const r = p.open(nullConsumer);
             assert.equal(r.read("length"), 1);
             assert.equal(r.read("0" as any), 0);
             assert.equal(r.read("1" as any), undefined);
 
-            const v = p.openVector(new NullConsumer());
+            const v = p.openVector(nullConsumer);
             assert.equal(v.length, 1);
             assert.equal(v.read(0), 0);
             assert.equal(v.read(1), undefined);
+        });
+
+        it("handles cycles", () => {
+            const root: any[] = [];
+            const child = [ root ];
+            root.push(child);
+
+            const p = produce(root);
+            const r = p.openVector(nullConsumer);
+            const childProducer = r.read(0);
+            const childReader = childProducer.open(nullConsumer);
+            assert.equal(childReader.read(0), p);
         });
     });
 });

--- a/packages/core/nano/test/produce.spec.ts
+++ b/packages/core/nano/test/produce.spec.ts
@@ -1,0 +1,31 @@
+import "mocha";
+import { strict as assert } from "assert";
+import { produce } from "../src/produce";
+import { NullConsumer } from "./util";
+
+describe("produce()", () => {
+    describe("object", () => {
+        it("supports open(), but not openVector()", () => {
+            const p = produce({ a: 1 });
+            assert.equal("openVector" in p, false);
+            const r = p.open(new NullConsumer());
+            assert.equal(r.read("a"), 1);
+            assert.equal(r.read("b" as any), undefined);
+        });
+    })
+
+    describe("array", () => {
+        it("supports open() and openVector()", () => {
+            const p = produce([0]);
+            const r = p.open(new NullConsumer());
+            assert.equal(r.read("length"), 1);
+            assert.equal(r.read("0" as any), 0);
+            assert.equal(r.read("1" as any), undefined);
+
+            const v = p.openVector(new NullConsumer());
+            assert.equal(v.length, 1);
+            assert.equal(v.read(0), 0);
+            assert.equal(v.read(1), undefined);
+        });
+    });
+});

--- a/packages/core/nano/test/util.ts
+++ b/packages/core/nano/test/util.ts
@@ -1,7 +1,9 @@
 import { IConsumer, IVectorConsumer, IProducer, IVectorProducer } from "../src/types";
 
-/** A generic test consumer that ignores all change notifications. */
-export class NullConsumer<T> implements IConsumer<T>, IVectorConsumer<T> {
+class NullConsumer<T> implements IConsumer<T>, IVectorConsumer<T> {
     public valueChanged<U extends T, K extends keyof U>(key: K, value: U[K], producer: IProducer<U>): void {}
     public itemsChanged(index: number, numRemoved: number, itemInserted: T[], producer: IVectorProducer<T>): void {}
 }
+
+/** A generic test consumer that ignores all change notifications. */
+export const nullConsumer: IConsumer<unknown> & IVectorConsumer<unknown> = new NullConsumer<unknown>();

--- a/packages/core/nano/test/util.ts
+++ b/packages/core/nano/test/util.ts
@@ -1,0 +1,7 @@
+import { IConsumer, IVectorConsumer, IProducer, IVectorProducer } from "../src/types";
+
+/** A generic test consumer that ignores all change notifications. */
+export class NullConsumer<T> implements IConsumer<T>, IVectorConsumer<T> {
+    public valueChanged<U extends T, K extends keyof U>(key: K, value: U[K], producer: IProducer<U>): void {}
+    public itemsChanged(index: number, numRemoved: number, itemInserted: T[], producer: IVectorProducer<T>): void {}
+}

--- a/packages/test/example/package.json
+++ b/packages/test/example/package.json
@@ -11,6 +11,7 @@
     "@tiny-calc/nano": "^0.0.2"
   },
   "devDependencies": {
+    "@types/node": "^10.0.0",
     "rimraf": "^2.6.3",
     "ts-node": "^8.1.0",
     "typescript": "^3.4.3"


### PR DESCRIPTION
A benchmark summing 10,000 array items shows no difference between accessing the native array, reading the array via a cached IReader, or performing an `open(consumer).read(index)` on every array item.

This is achieved by implementing IProducer<> and IReader<> "in-place" on the original objects in the JSON graph (and returning 'this').  After inlining, v8 is able to recognize this is a simple property lookup on the original object.

Unfortunately, freezing the underlying graph on `produce()` may need to be a DBG feature as there appears to be a severe performance penalty when reading items from a frozen array (~2 orders of magnitude on Node v12.1)