### PR TITLE
Sheetlet: ~3x speedup on dense dependencies via integer keys

### DIFF
--- a/packages/common/tool-config/package.json
+++ b/packages/common/tool-config/package.json
@@ -4,7 +4,8 @@
   "description": "Common config for build tools",
   "sideEffects": "false",
   "scripts": {
-    "build": "echo No build steps necessary."
+    "build": "echo No build steps necessary.",
+    "test": "echo No test steps necessary."
   },
   "author": "Microsoft",
   "license": "MIT"

--- a/packages/core/micro/bench/profile.ts
+++ b/packages/core/micro/bench/profile.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Runs RecalcTest in a tight loop outside of the Benchmark suite to make profiling
+// analysis a bit easier.
+
+import { makeBenchmark, evalSheet } from "../test/sheets";
+
+function recalcTest(size: number) {
+    const { sheet, setAt } = makeBenchmark(size);
+    evalSheet(sheet, size);
+    console.time("profile");
+    for (let i = 0; i < 1000; i++) {
+        setAt(0, 0, i);
+        evalSheet(sheet, size);
+    }
+    console.timeEnd("profile");
+}
+
+recalcTest(10);

--- a/packages/core/micro/bench/sheetlet.suite.ts
+++ b/packages/core/micro/bench/sheetlet.suite.ts
@@ -1,20 +1,17 @@
 import { Suite } from "benchmark";
 import { consume } from "./util";
-import "mocha";
 import { evalSheet, makeBenchmark } from "../test/sheets";
 
 const suite = new Suite();
 export const suites: Suite[] = [ suite ];
 
-// All of these benchmarks involve a square matrix where all cells except [0,0] are a sum
-// of all cells above and to the left.  Changing [0,0] recalculates the entire matrix.
+// These benchmarks involve a square matrix where all cells except [0,0] are a sum
+// of all cells above and to the left.  Changing [0,0] causes all other cells to recalculate.
 
 function cachedTest(size: number) {
-    const suite = new Suite();
     const { sheet } = makeBenchmark(size);
     evalSheet(sheet, size);
     suite.add(`Cached: ${size}x${size}`, () => { consume(evalSheet(sheet, size)); });
-    suites.push(suite);
 }
 
 function recalcTest(size: number) {
@@ -25,7 +22,6 @@ function recalcTest(size: number) {
         setAt(0, 0, i = ~i);    // Toggle [0,0] between 1 and -2
         consume(evalSheet(sheet, size));
     });
-    suites.push(suite);
 }
 
 cachedTest(2);

--- a/packages/core/micro/package.json
+++ b/packages/core/micro/package.json
@@ -7,10 +7,13 @@
     "build": "tsc",
     "clean": "rimraf ./dist *.build.log",
     "dev": "npm run build -- --watch",
+    "prof": "tsc --project tsconfig.prof.json && node --prof temp/bench/profile.js && node --prof-process isolate-*-v8.log > profile.log && rm isolate-*-v8.log",
     "test": "mocha -r ts-node/register test/**/*.spec.ts"
   },
+  "dependencies": {
+    "@tiny-calc/nano": "^0.0.2"
+  },
   "devDependencies": {
-    "@tiny-calc/nano": "^0.0.2",
     "@tiny-calc/tool-config": "^0.0.2",
     "@types/benchmark": "^1.0.31",
     "@types/mocha": "^5.2.6",

--- a/packages/core/micro/src/key.ts
+++ b/packages/core/micro/src/key.ts
@@ -1,0 +1,23 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Note that the exponents sum to 2^53, which fully utilizes the exact integer range of a Float64.
+export const maxRows = 0x100000000 as const;    // 2^32 = x4096 Excel maximum of 1,048,576 rows
+export const maxCols = 0x200000 as const;       // 2^21 =  x128 Excel maximum of 16,384 columns
+const colMask = 0x1FFFFF as const;
+
+/** Encode the given RC0 `row`/`col` as a 53b integer key. */
+export function pointToKey(row: number, col: number) {
+    // Note: Can not replace multiply with shift as product exceeds 32b.
+    return row * maxCols + col;
+}
+
+/** Decode the given `key` to it's RC0 row/col. */
+export function keyToPoint(position: number) {
+    // Note: Can not replace division with shift as numerator exceeds 32b.
+    const row = (position / maxCols) >>> 0;
+    const col = position & colMask;
+    return [ row, col ];
+}

--- a/packages/core/micro/test/key.spec.ts
+++ b/packages/core/micro/test/key.spec.ts
@@ -1,0 +1,31 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { strict as assert } from "assert";
+import "mocha";
+import { maxRows, maxCols, pointToKey, keyToPoint } from "../src/key";
+
+describe("Matrix Key", () => {
+    const valid = [
+        [0, 0],                     // Trivial
+        [0, 1],
+        [1, 0],
+        [maxRows - 1, 0],           // Limits
+        [0, maxCols - 1],
+        [maxRows - 1, maxCols - 1],
+    ];
+
+    for (const expected of valid) {
+        it(`[${expected[0]},${expected[1]}]`, () => {
+            const key = pointToKey(expected[0], expected[1]);
+            const actual = keyToPoint(key);
+            assert.deepEqual(actual, expected);
+        });
+    }
+
+    it("Key mapping should fully utilize, but not exceed, the safe integer range", () => {
+        assert(pointToKey(maxRows - 1, maxCols - 1) === Number.MAX_SAFE_INTEGER);
+    });
+});

--- a/packages/core/micro/test/sheetlet.spec.ts
+++ b/packages/core/micro/test/sheetlet.spec.ts
@@ -76,9 +76,9 @@ describe("Sheetlet", () => {
             setAt(0, 0, 1);
             assert.deepEqual(
                 extract(sheet, 3, 3), [
-                    [1, 1, 2],
-                    [1, 2, 5],
-                    [2, 4, 11],
+                    [1, 1,  2],
+                    [1, 3,  8],
+                    [2, 8, 26],
                 ]);
         });
     });

--- a/packages/core/micro/test/sheets.ts
+++ b/packages/core/micro/test/sheets.ts
@@ -1,23 +1,30 @@
-import { c0ToName } from "@tiny-calc/nano/test/matrix";
 import { createSheetlet, ISheetlet } from "../src/sheetlet";
-import { Matrix } from "../src/matrix";
+import { c0ToName, Matrix } from "../src/matrix";
 import { consume } from "../bench/util";
 import { Primitive } from "@tiny-calc/nano";
 
-export function makeBenchmark(size: number) {
+export function makeBenchmark(size: number): { sheet: ISheetlet, setAt: (row: number, col: number, value: Primitive) => void } {
     const cells = new Array(size * size);
 
+    cells[0] = 0;
+
+    // Cells in column 0 sum all cells above.
     for (let r = 1; r < size; r++) {
         cells[r * size] = `=SUM(A1:A${r})`;
     }
 
-    for (let r = 0; r < size; r++) {
-        for (let c = 1; c < size; c++) {
-            cells[r * size + c] = `=SUM(A1:${c0ToName(c - 1)}${r + 1})`;
-        }
+    // Cells in row 0 sum all cells to the left.
+    for (let c = 1; c < size; c++) {
+        cells[c] = `=SUM(A1:${c0ToName(c - 1)}1)`;
     }
 
-    cells[0] = 0;
+    // Interior cells sum all cells above and/or to the left.
+    for (let r = 1; r < size; r++) {
+        for (let c = 1; c < size; c++) {
+            const col = c0ToName(c);
+            cells[r * size + c] = `=SUM(${col}1:${col}${r}) + SUM(A1:${c0ToName(c - 1)}${r + 1})`;
+        }
+    }
 
     const matrix = new Matrix(size, size, cells);
     const sheet = createSheetlet(matrix);

--- a/packages/core/micro/tsconfig.prof.json
+++ b/packages/core/micro/tsconfig.prof.json
@@ -1,0 +1,9 @@
+{
+    "extends": "@tiny-calc/tool-config/tsconfig.json",
+    "compilerOptions": {
+        "declarationDir": "./temp",
+        "rootDir": ".",
+        "outDir": "./temp"
+    },
+    "include": ["bench/profile.ts"]
+}

--- a/packages/core/nano/bench/json.ts
+++ b/packages/core/nano/bench/json.ts
@@ -3,7 +3,7 @@ import { consume } from "./util";
 import { produce } from "../src/produce";
 import { nullConsumer } from "../test/util";
 
-export const suites = [];
+export const suites: Suite[] = [];
 
 {
     const array = new Array<number>(10000).fill(0).map(() => Math.random());


### PR DESCRIPTION
Per the TODO in Sheetlet, replaces string keys with numbers for a significant speedup during recalculation of dense dependency graphs.