### PR TITLE
Make context type an object

### DIFF
--- a/packages/core/micro/src/sheetlet.ts
+++ b/packages/core/micro/src/sheetlet.ts
@@ -187,7 +187,7 @@ interface CellReader {
 
 interface BuildHost extends CellReader {
     binder: Binder<number>;
-    rootContext: CalcValue<Point>;
+    rootContext: CalcObj<Point>;
 }
 
 function createInvalidator(reader: CellReader, binder: Binder<number>) {
@@ -682,7 +682,7 @@ class Sheetlet implements ISheetlet {
 
     public readonly binder = initBinder();
 
-    public readonly rootContext: CalcValue<Point> = {
+    public readonly rootContext: CalcObj<Point> = {
         read: (property, origin) => {
             if (property in funcs) {
                 return funcs[property];

--- a/packages/core/nano/src/compiler.ts
+++ b/packages/core/nano/src/compiler.ts
@@ -10,6 +10,7 @@ import {
 
 import {
     binaryOperationsMap,
+    CalcObj,
     CalcValue,
     Delayed,
     ef,
@@ -158,11 +159,11 @@ function compileAST(gensym: () => number, scope: Record<string, string>, f: Form
     }
 }
 
-type RawFormula = <O>(trace: Trace, host: O, context: CalcValue<O>, ops: OpContext, ef: LiftedCore) => Delayed<CalcValue<O>>;
+type RawFormula = <O>(trace: Trace, host: O, context: CalcObj<O>, ops: OpContext, ef: LiftedCore) => Delayed<CalcValue<O>>;
 
 const parse = createParser(simpleSink, errorHandler);
 
-const formula = (raw: RawFormula): Formula => <O>(host: O, context: CalcValue<O>) => {
+const formula = (raw: RawFormula): Formula => <O>(host: O, context: CalcObj<O>) => {
     const [data, trace] = makeTracer();
     const result = raw(trace, host, context, ops, ef);
     return [data, result];

--- a/packages/core/nano/src/core.ts
+++ b/packages/core/nano/src/core.ts
@@ -173,5 +173,5 @@ export const ops: OpContext = {
     negate: liftUnaryOp((x: any) => -x),
 };
 
-export type Formula = <O>(host: O, context: CalcValue<O>) => [Pending<unknown>[], Delayed<CalcValue<O>>];
+export type Formula = <O>(host: O, context: CalcObj<O>) => [Pending<unknown>[], Delayed<CalcValue<O>>];
 


### PR DESCRIPTION
There is no good reason to make the context a calc value.