### PR TITLE
Micro: ISheetlet implementations should not `setCellText()`

### DIFF
--- a/packages/core/micro/src/key.ts
+++ b/packages/core/micro/src/key.ts
@@ -16,8 +16,12 @@ export function pointToKey(row: number, col: number) {
 
 /** Decode the given `key` to it's RC0 row/col. */
 export function keyToPoint(position: number) {
-    // Note: Can not replace division with shift as numerator exceeds 32b.
+    // Can not replace division with shift as numerator exceeds 32b, but the quotient can
+    // be safely converted to a Uint32 in lieu of 'Math.floor()' for a measurable speedup.
     const row = (position / maxCols) >>> 0;
+
+    // The column portion is less than 32b and resides in the low bits of the Uint53.  We
+    // can safely extract it with mask.
     const col = position & colMask;
     return [ row, col ];
 }

--- a/packages/core/micro/src/matrix.ts
+++ b/packages/core/micro/src/matrix.ts
@@ -4,7 +4,6 @@ export interface IMatrix {
    readonly numRows: number;
    readonly numCols: number;
    loadCellText: (row: number, col: number) => Primitive | undefined;
-   storeCellText: (row: number, col: number, value: Primitive | undefined) => void;
    loadCellData: (row: number, col: number) => object | undefined;
    storeCellData: (row: number, col: number, value: object | undefined) => void;
 }

--- a/packages/core/micro/src/sheetlet.ts
+++ b/packages/core/micro/src/sheetlet.ts
@@ -671,8 +671,7 @@ class Range<O> implements CalcObj<O> {
  * Sheetlet: a grid of incrementally recalculating formulas.
  */
 export interface ISheetlet {
-    refreshFromModel: (row: number, col: number) => void;
-    setCellText: (row: number, col: number, value: Primitive | undefined) => void;
+    invalidate: (row: number, col: number) => void;
     evaluateCell: (row: number, col: number) => Primitive | undefined;
     evaluateFormula: (formula: string) => Primitive | undefined;
 }
@@ -711,21 +710,15 @@ class Sheetlet implements ISheetlet {
         parseRef: this.parseRef.bind(this),
     };
 
-    private readonly invalidate = createInvalidator({
+    private readonly invalidateKey = createInvalidator({
         readCell: this.getCell.bind(this),
     }, this.binder);
 
     constructor(private readonly matrix: IMatrix) { }
 
-    public refreshFromModel(row: number, col: number) {
+    public invalidate(row: number, col: number) {
         this.matrix.storeCellData(row, col, undefined);
-        this.invalidate(pointToKey(row, col));
-    }
-
-    public setCellText(row: number, col: number, value: Primitive | undefined) {
-        // setting text clears any cell data
-        this.matrix.storeCellText(row, col, value);
-        this.invalidate(pointToKey(row, col));
+        this.invalidateKey(pointToKey(row, col));
     }
 
     public parseRef(text: string): Point | undefined {

--- a/packages/core/micro/test/sheets.ts
+++ b/packages/core/micro/test/sheets.ts
@@ -33,7 +33,7 @@ export function makeBenchmark(size: number): { sheet: ISheetlet, setAt: (row: nu
         sheet,
         setAt: (row: number, col: number, value: Primitive) => {
             matrix.storeCellText(row, col, value);
-            sheet.refreshFromModel(row, col);
+            sheet.invalidate(row, col);
         }
     };
 }


### PR DESCRIPTION
For historical reasons, setting the cell text was proxied through the ISheetlet.  With this change, the application is now responsible for updating the cell's value and then notifying the ISheetlet that the cell has been invalidated.

This allows the application to allow setting arbitrary data in cells (e.g., rich text) and then covert the value for the ISheetlet when `getCellText()` is invoked.