### PR TITLE
Nano: Update IMatrixConsumer interface

### DIFF
--- a/packages/core/nano/src/index.ts
+++ b/packages/core/nano/src/index.ts
@@ -30,8 +30,10 @@ export {
     IProducer,
     IVectorConsumer,
     IVectorProducer,
+    IVectorReader,
     IMatrixConsumer,
-    IMatrixProducer
+    IMatrixProducer,
+    IMatrixReader
 } from "./types";
 
 export {

--- a/packages/core/nano/src/types.ts
+++ b/packages/core/nano/src/types.ts
@@ -52,7 +52,7 @@ export interface IProducer<T> {
 
 export interface IVectorConsumer<T> {
     /** Notification that a range of items have been inserted, removed, and/or replaced in the given vector. */
-    itemsChanged(index: number, numRemoved: number, itemsInserted: T[], producer: IVectorProducer<T>): void;
+    itemsChanged(index: number, numRemoved: number, itemsInserted: ReadonlyArray<T>, producer: IVectorProducer<T>): void;
 }
 
 export interface IVectorReader<T> {

--- a/packages/core/nano/src/types.ts
+++ b/packages/core/nano/src/types.ts
@@ -73,13 +73,17 @@ export interface IVectorProducer<T> {
 
 export interface IMatrixConsumer<T> {
     /** Notification that rows have been inserted, removed, and/or replaced in the given matrix. */
-    rowsChanged(row: number, numRemoved: number, rowsInserted: T[], producer: IMatrixProducer<T>): void;
+    rowsChanged(row: number, numRemoved: number, numInserted: number, producer: IMatrixProducer<T>): void;
 
     /** Notification that cols have been inserted, removed, and/or replaced in the given matrix. */
-    colsChanged(col: number, numRemoved: number, colsInserted: T[], producer: IMatrixProducer<T>): void;
+    colsChanged(col: number, numRemoved: number, numInserted: number, producer: IMatrixProducer<T>): void;
 
-    /** Notification that a range of cells have been replaced in the given matrix. */
-    cellsReplaced(row: number, col: number, numRows: number, numCols: number, values: T[], producer: IMatrixProducer<T>): void;
+    /**
+     * Notification that a range of cells have been replaced in the given matrix.  If the source
+     * matrix has the new cell values already in an array, it may optionally pass these to consumers
+     * as an optimization.
+     */
+    cellsChanged(row: number, col: number, numRows: number, numCols: number, values: ReadonlyArray<T> | undefined, producer: IMatrixProducer<T>): void;
 }
 
 export interface IMatrixReader<T> {

--- a/packages/core/nano/test/util/loggingConsumer.ts
+++ b/packages/core/nano/test/util/loggingConsumer.ts
@@ -1,17 +1,6 @@
 import { IConsumer, IVectorConsumer, IMatrixConsumer, IProducer, IVectorProducer, IMatrixProducer } from "../../src/types";
 import { strict as assert } from "assert";
 
-class NullConsumer<T> implements IConsumer<T>, IVectorConsumer<T>, IMatrixConsumer<T> {
-    public rowsChanged(): void { }
-    public colsChanged(): void { }
-    public cellsReplaced(): void { }
-    public valueChanged(): void {}
-    public itemsChanged(): void {}
-}
-
-/** A generic test consumer that ignores all change notifications. */
-export const nullConsumer: IConsumer<unknown> & IVectorConsumer<unknown> & IMatrixConsumer<unknown> = new NullConsumer<unknown>();
-
 export class LoggingConsumer<T> implements IConsumer<T>, IVectorConsumer<T>, IMatrixConsumer<T> {
     public readonly log: any[] = [];
 
@@ -31,15 +20,15 @@ export class LoggingConsumer<T> implements IConsumer<T>, IVectorConsumer<T>, IMa
     // #endregion IVectorConsumer<T>
     
     // #region IMatrixConsumer<T>
-    public rowsChanged(row: number, numRemoved: number, rowsInserted: T[], producer: IMatrixProducer<T>): void {
-        this.log.push({ row, numRemoved, rowsInserted, producer: this.getProducerId(producer) });
+    public rowsChanged(row: number, numRemoved: number, numInserted: number, producer: IMatrixProducer<T>): void {
+        this.log.push({ row, numRemoved, numInserted, producer: this.getProducerId(producer) });
     }
     
-    public colsChanged(col: number, numRemoved: number, colsInserted: T[], producer: IMatrixProducer<T>): void {
-        this.log.push({ col, numRemoved, colsInserted, producer: this.getProducerId(producer) });
+    public colsChanged(col: number, numRemoved: number, numInserted: number, producer: IMatrixProducer<T>): void {
+        this.log.push({ col, numRemoved, numInserted, producer: this.getProducerId(producer) });
     }
     
-    public cellsReplaced(row: number, col: number, numRows: number, numCols: number, values: T[], producer: IMatrixProducer<T>): void {
+    public cellsChanged(row: number, col: number, numRows: number, numCols: number, values: ReadonlyArray<T>, producer: IMatrixProducer<T>): void {
         this.log.push({ row, col, numRows, numCols, values, producer: this.getProducerId(producer) });
     }
     // #endregion IMatrixConsumer<T>

--- a/packages/core/nano/test/util/loggingConsumer.ts
+++ b/packages/core/nano/test/util/loggingConsumer.ts
@@ -14,7 +14,7 @@ export class LoggingConsumer<T> implements IConsumer<T>, IVectorConsumer<T>, IMa
     // #endregion IConsumer<T>
     
     // #region IVectorConsumer<T>
-    public itemsChanged(index: number, numRemoved: number, itemsInserted: T[], producer: IVectorProducer<T>): void {
+    public itemsChanged(index: number, numRemoved: number, itemsInserted: ReadonlyArray<T>, producer: IVectorProducer<T>): void {
         this.log.push({ index, numRemoved, itemsInserted, producer: this.getProducerId(producer) });
     }
     // #endregion IVectorConsumer<T>

--- a/packages/core/nano/test/util/nullConsumer.ts
+++ b/packages/core/nano/test/util/nullConsumer.ts
@@ -3,9 +3,9 @@ import { IConsumer, IVectorConsumer, IMatrixConsumer } from "../../src/types";
 class NullConsumer<T> implements IConsumer<T>, IVectorConsumer<T>, IMatrixConsumer<T> {
     public rowsChanged(): void { }
     public colsChanged(): void { }
-    public cellsReplaced(): void { }
-    public valueChanged(): void {}
-    public itemsChanged(): void {}
+    public cellsChanged(): void { }
+    public valueChanged(): void { }
+    public itemsChanged(): void { }
 }
 
 /** A generic test consumer that ignores all change notifications. */


### PR DESCRIPTION
Remove `values: T[]` from row/col insertion/removal notifications.  Could bring this back as an optional arg, but currently insert/remove ops always insert empty row/cols.

Rename 'cellsReplaced' -> `cellsChanged` to match other IConsumer interfaces.

Make `values: T[]` optional on `cellsChanged`.  This could be useful for bulk set operations, but shouldn't be required.
