### PR TITLE
Implement Sheetlet as Producer/Consumer

### DIFF
--- a/packages/core/micro/bench/sheetlet.suite.ts
+++ b/packages/core/micro/bench/sheetlet.suite.ts
@@ -10,8 +10,9 @@ export const suites: Suite[] = [ suite ];
 
 function cachedTest(size: number) {
     const { sheet } = makeBenchmark(size);
-    evalSheet(sheet.openMatrix(undefined as any), size);
-    suite.add(`Cached: ${size}x${size}`, () => { consume(evalSheet(sheet.openMatrix(undefined as any), size)); });
+    const reader = sheet.openMatrix(undefined as any);
+    evalSheet(reader, size);
+    suite.add(`Cached: ${size}x${size}`, () => { consume(evalSheet(reader, size)); });
 }
 
 function recalcTest(size: number) {

--- a/packages/core/micro/bench/sheetlet.suite.ts
+++ b/packages/core/micro/bench/sheetlet.suite.ts
@@ -10,17 +10,17 @@ export const suites: Suite[] = [ suite ];
 
 function cachedTest(size: number) {
     const { sheet } = makeBenchmark(size);
-    evalSheet(sheet, size);
-    suite.add(`Cached: ${size}x${size}`, () => { consume(evalSheet(sheet, size)); });
+    evalSheet(sheet.openMatrix(undefined as any), size);
+    suite.add(`Cached: ${size}x${size}`, () => { consume(evalSheet(sheet.openMatrix(undefined as any), size)); });
 }
 
 function recalcTest(size: number) {
     const { sheet, setAt } = makeBenchmark(size);
-    evalSheet(sheet, size);
+    evalSheet(sheet.openMatrix(undefined as any), size);
     let i = 1;
     suite.add(`Recalc: ${size}x${size}`, () => { 
         setAt(0, 0, i = ~i);    // Toggle [0,0] between 1 and -2
-        consume(evalSheet(sheet, size));
+        consume(evalSheet(sheet.openMatrix(undefined as any), size));
     });
 }
 

--- a/packages/core/micro/src/binder.ts
+++ b/packages/core/micro/src/binder.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { pointToKey } from "./key";
+import { createMatrix } from "./matrix";
+import { Binder } from "./types";
+
+const newSet = () => new Set<number>();
+
+export function initBinder(): Binder {
+    let grid = createMatrix<Set<number>>();
+    const volatile = new Set<number>();
+    return {
+        getVolatile: () => volatile,
+        bindCell(fromRow: number, fromCol: number, toRow: number, toCol: number) {
+            const s = grid.readOrWrite(fromRow, fromCol, newSet)
+            if (s) {
+                s.add(pointToKey(toRow, toCol));
+            }
+        },
+        getDependents(row: number, col: number) {
+            return grid.read(row, col);
+        },
+        clear: () => {
+            grid = createMatrix();
+        },
+    };
+}

--- a/packages/core/micro/src/binder.ts
+++ b/packages/core/micro/src/binder.ts
@@ -4,13 +4,13 @@
  */
 
 import { pointToKey } from "./key";
-import { createMatrix } from "./matrix";
+import { createGrid } from "./matrix";
 import { Binder } from "./types";
 
 const newSet = () => new Set<number>();
 
 export function initBinder(): Binder {
-    let grid = createMatrix<Set<number>>();
+    let grid = createGrid<Set<number>>();
     const volatile = new Set<number>();
     return {
         getVolatile: () => volatile,
@@ -24,7 +24,7 @@ export function initBinder(): Binder {
             return grid.read(row, col);
         },
         clear: () => {
-            grid = createMatrix();
+            grid = createGrid();
         },
     };
 }

--- a/packages/core/micro/src/binder.ts
+++ b/packages/core/micro/src/binder.ts
@@ -23,6 +23,12 @@ export function initBinder(): Binder {
         getDependents(row: number, col: number) {
             return grid.read(row, col);
         },
+        clearDependents(row: number, col: number) {
+            const s = grid.read(row, col);
+            if (s) {
+                s.clear();
+            }
+        },
         clear: () => {
             grid = createGrid();
         },

--- a/packages/core/micro/src/cell.ts
+++ b/packages/core/micro/src/cell.ts
@@ -1,0 +1,78 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    Primitive,
+} from "@tiny-calc/nano";
+
+import {
+    CalcFlags,
+    CalcState,
+    Cell,
+    CellValue,
+    FormulaCell,
+    Value,
+    ValueCell
+} from "./types";
+
+import * as assert from "assert";
+
+function valueCell(content: Primitive): ValueCell {
+    return { state: CalcState.Clean, content };
+}
+
+export function isFormulaCell(cell: Cell): cell is FormulaCell<CellValue> {
+    return "formula" in cell;
+}
+
+function makeValueCell(value: Primitive) {
+    let content: Primitive;
+    switch (typeof value) {
+        case "number":
+        case "boolean":
+            content = value;
+            break;
+        case "string":
+            content = parseValue(value);
+            break;
+        default:
+            return assert.fail(`Unknown primitive ${value}`)
+    }
+    return valueCell(content);
+}
+
+function makeFormulaCell(row: number, col: number, text: string): FormulaCell<CellValue> {
+    return {
+        state: CalcState.Dirty,
+        flags: CalcFlags.None,
+        row,
+        col,
+        formula: text,
+        value: undefined,
+        node: undefined,
+    };
+}
+
+export function makeCell(row: number, col: number, value: Value) {
+    if (value === undefined || value === "") {
+        return undefined;
+    }
+    if (typeof value === "string" && value[0] === "=") {
+        return makeFormulaCell(row, col, value.substring(1));
+    }
+    return makeValueCell(value);
+}
+
+function parseValue(value: string): Primitive {
+    const upper = value.toUpperCase();
+    if (upper === "TRUE") {
+        return true;
+    }
+    if (upper === "FALSE") {
+        return false;
+    }
+    const asNumber = Number(value);
+    return isNaN(asNumber) ? value : asNumber;
+}

--- a/packages/core/micro/src/core.ts
+++ b/packages/core/micro/src/core.ts
@@ -12,7 +12,7 @@ import {
 import {
     FunctionFiber,
     FunctionTask,
-    PendingValue,
+    PendingTask,
     Range,
 } from "./types";
 
@@ -24,7 +24,7 @@ export function isPending(content: any): content is Pending<unknown> {
     return typeof content === "object" && "kind" in content && content.kind === "Pending";
 }
 
-export function isPendingFiber(content: any): content is PendingValue {
+export function isPendingTask(content: any): content is PendingTask<unknown> {
     return isPending(content) && "fiber" in content;
 }
 
@@ -37,6 +37,6 @@ export const errors = {
     cycle: makeError("#CYCLE!"),
     ref: makeError("#REF!"),
     fallbackCoercion: makeError("#VALUE!"),
-    compileFailure: makeError("#COMPILE!"),
+    parseFailure: makeError("#PARSE!"),
     evalFailure: makeError("#EVAL!"),
 } as const;

--- a/packages/core/micro/src/core.ts
+++ b/packages/core/micro/src/core.ts
@@ -10,8 +10,12 @@ import {
 } from "@tiny-calc/nano";
 
 import {
+    CalcFlags,
+    Fiber,
+    FormulaCell,
     FunctionFiber,
     FunctionRunner,
+    FunctionSkolem,
     FunctionTask,
     PendingTask,
     Range,
@@ -19,9 +23,9 @@ import {
 } from "./types";
 
 export function makePendingFunction<V>(
-    name: FunctionTask, range: Range, context: RangeContext, row: number, column: number, runner: FunctionRunner<V>
+    state: FunctionTask, range: Range, context: RangeContext, row: number, column: number, runner: FunctionRunner<FunctionSkolem, V>
 ): FunctionFiber<V> {
-    return { flag: name, range, context, row, column, runner };
+    return { state, range, context, flags: CalcFlags.None, row, column, runner };
 }
 
 export function isPending(content: any): content is Pending<unknown> {
@@ -30,6 +34,10 @@ export function isPending(content: any): content is Pending<unknown> {
 
 export function isPendingTask(content: any): content is PendingTask<any> {
     return isPending(content) && "fiber" in content;
+}
+
+export function isFormulaFiber<T>(fiber: Fiber<T>): fiber is FormulaCell<T> {
+    return typeof fiber.state === "number";
 }
 
 /**

--- a/packages/core/micro/src/core.ts
+++ b/packages/core/micro/src/core.ts
@@ -17,14 +17,14 @@ import {
 } from "./types";
 
 export function makePendingFunction<V>(name: FunctionTask, range: Range, row: number, column: number, current: V): FunctionFiber<V> {
-    return { flag: name, range, row, column, current };
+    return { flag: name, range, row, column, current, prev: undefined, next: undefined };
 }
 
 export function isPending(content: any): content is Pending<unknown> {
     return typeof content === "object" && "kind" in content && content.kind === "Pending";
 }
 
-export function isPendingTask(content: any): content is PendingTask<unknown> {
+export function isPendingTask(content: any): content is PendingTask<any> {
     return isPending(content) && "fiber" in content;
 }
 

--- a/packages/core/micro/src/core.ts
+++ b/packages/core/micro/src/core.ts
@@ -11,13 +11,17 @@ import {
 
 import {
     FunctionFiber,
+    FunctionRunner,
     FunctionTask,
     PendingTask,
     Range,
+    RangeContext,
 } from "./types";
 
-export function makePendingFunction<V>(name: FunctionTask, range: Range, row: number, column: number, current: V): FunctionFiber<V> {
-    return { flag: name, range, row, column, current, prev: undefined, next: undefined };
+export function makePendingFunction<V>(
+    name: FunctionTask, range: Range, context: RangeContext, row: number, column: number, runner: FunctionRunner<V>
+): FunctionFiber<V> {
+    return { flag: name, range, context, row, column, runner };
 }
 
 export function isPending(content: any): content is Pending<unknown> {

--- a/packages/core/micro/src/core.ts
+++ b/packages/core/micro/src/core.ts
@@ -38,6 +38,7 @@ export function isPendingTask(content: any): content is PendingTask<any> {
 export const errors = {
     ...errorsC,
     unknownField: makeError("#UNKNOWN!"),
+    calc: makeError("#CALC!"),
     cycle: makeError("#CYCLE!"),
     ref: makeError("#REF!"),
     fallbackCoercion: makeError("#VALUE!"),

--- a/packages/core/micro/src/core.ts
+++ b/packages/core/micro/src/core.ts
@@ -1,0 +1,42 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    errors as errorsC,
+    makeError,
+    Pending,
+} from "@tiny-calc/nano";
+
+import {
+    FunctionFiber,
+    FunctionTask,
+    PendingValue,
+    Range,
+} from "./types";
+
+export function makePendingFunction<V>(name: FunctionTask, range: Range, row: number, column: number, current: V): FunctionFiber<V> {
+    return { flag: name, range, row, column, current };
+}
+
+export function isPending(content: any): content is Pending<unknown> {
+    return typeof content === "object" && "kind" in content && content.kind === "Pending";
+}
+
+export function isPendingFiber(content: any): content is PendingValue {
+    return isPending(content) && "fiber" in content;
+}
+
+/**
+ * Basic errors.
+ */
+export const errors = {
+    ...errorsC,
+    unknownField: makeError("#UNKNOWN!"),
+    cycle: makeError("#CYCLE!"),
+    ref: makeError("#REF!"),
+    fallbackCoercion: makeError("#VALUE!"),
+    compileFailure: makeError("#COMPILE!"),
+    evalFailure: makeError("#EVAL!"),
+} as const;

--- a/packages/core/micro/src/formula.ts
+++ b/packages/core/micro/src/formula.ts
@@ -46,7 +46,7 @@ function parseCellRef(id: string): Reference | string {
             pos++;
             continue;
         }
-        else if (ch >= CharacterCodes.A && ch <= CharacterCodes.Z) {
+        else if (ch >= CharacterCodes.a && ch <= CharacterCodes.z) {
             col1 = (col1 - 96) * 26;
             pos++;
             continue;
@@ -92,7 +92,7 @@ function parseCellRef(id: string): Reference | string {
             pos++;
             continue;
         }
-        else if (ch >= CharacterCodes.A && ch <= CharacterCodes.Z) {
+        else if (ch >= CharacterCodes.a && ch <= CharacterCodes.z) {
             col2 = (col2 - 96) * 26;
             pos++;
             continue;

--- a/packages/core/micro/src/formula.ts
+++ b/packages/core/micro/src/formula.ts
@@ -65,7 +65,6 @@ function parseCellRef(id: string): Reference | string {
 
     if (start === pos) { return id };
 
-    // Parse row numbers
     const row1 = Number(id.substring(start, pos));
     if (isNaN(row1)) {
         return id;
@@ -77,7 +76,7 @@ function parseCellRef(id: string): Reference | string {
         return id;
     }
 
-    // Skips the ':'.
+    // Skips the ':'
     pos++;
 
     if (pos < end && id.charCodeAt(pos) === CharacterCodes.$) {
@@ -111,7 +110,6 @@ function parseCellRef(id: string): Reference | string {
 
     if (start2 === pos) { return id };
 
-    // Parse row numbers
     const row2 = Number(id.substring(start2, pos));
     if (isNaN(row2)) {
         return id;

--- a/packages/core/micro/src/formula.ts
+++ b/packages/core/micro/src/formula.ts
@@ -28,6 +28,9 @@ const enum CharacterCodes {
 
 const isDigit = (ch: number) => ch >= CharacterCodes._0 && ch <= CharacterCodes._9;
 
+const maxRow = 2**20;
+const maxCol = 2**14;
+
 function parseCellRef(id: string): Reference | string {
     let col1 = 0;
 
@@ -54,6 +57,8 @@ function parseCellRef(id: string): Reference | string {
         break;
     }
 
+    if (col1 > maxCol) { return id; }
+
     if (pos < end && id.charCodeAt(pos) === CharacterCodes.$) {
         pos++;
     }
@@ -66,7 +71,7 @@ function parseCellRef(id: string): Reference | string {
     if (start === pos) { return id };
 
     const row1 = Number(id.substring(start, pos));
-    if (isNaN(row1)) {
+    if (isNaN(row1) || row1 > maxRow) {
         return id;
     }
 
@@ -99,6 +104,8 @@ function parseCellRef(id: string): Reference | string {
         break;
     }
 
+    if (col2 > maxCol) { return id; }
+
     if (pos < end && id.charCodeAt(pos) === CharacterCodes.$) {
         pos++;
     }
@@ -111,7 +118,7 @@ function parseCellRef(id: string): Reference | string {
     if (start2 === pos) { return id };
 
     const row2 = Number(id.substring(start2, pos));
-    if (isNaN(row2)) {
+    if (isNaN(row2) || row2 > maxRow) {
         return id;
     }
 

--- a/packages/core/micro/src/formula.ts
+++ b/packages/core/micro/src/formula.ts
@@ -1,0 +1,126 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    createAlgebra,
+    createBooleanErrorHandler,
+    createParser,
+    Parser,
+} from "@tiny-calc/nano";
+
+import {
+    FormulaNode,
+    Reference,
+} from "./types";
+
+const enum CharacterCodes {
+    $ = 0x24,
+    _0 = 0x30,
+    _9 = 0x39,
+    a = 0x61,
+    z = 0x7a,
+    A = 0x41,
+    Z = 0x5a,
+    colon = 0x3a,
+}
+
+const isDigit = (ch: number) => ch >= CharacterCodes._0 && ch <= CharacterCodes._0;
+
+function parseCellRef(id: string): Reference | string {
+    let col1 = 0;
+
+    let pos = 0;
+    const end = id.length;
+    
+    if (pos < end && id.charCodeAt(pos) === CharacterCodes.$) {
+        pos++;
+    }
+
+    // Parse column letters
+    while (pos < end) {
+        const ch = id.charCodeAt(pos);
+        if (ch >= CharacterCodes.A && ch <= CharacterCodes.Z) {
+            col1 = (col1 - 64) * 26;
+            pos++;
+            continue;
+        }
+        else if (ch >= CharacterCodes.A && ch <= CharacterCodes.Z) {
+            col1 = (col1 - 96) * 26;
+            pos++;
+            continue;
+        }
+        break;
+    }
+
+    if (pos < end && id.charCodeAt(pos) === CharacterCodes.$) {
+        pos++;
+    }
+
+    const start = pos;
+    while (pos < end && isDigit(id.charCodeAt(pos))) {
+        pos++;
+    }
+
+    if (start === pos) { return id };
+
+    // Parse row numbers
+    const row1 = Number(id.substring(start, pos));
+    if (isNaN(row1)) {
+        return id;
+    }
+
+    if (pos === end) { return { row1, col1 } }
+
+    if (pos < end && id.charCodeAt(pos) !== CharacterCodes.colon) {
+        return id;
+    }
+
+    // Skips the ':'.
+    pos++;
+
+    if (pos < end && id.charCodeAt(pos) === CharacterCodes.$) {
+        pos++;
+    }
+
+    let col2 = 0;
+    while (pos < end) {
+        const ch = id.charCodeAt(pos);
+        if (ch >= CharacterCodes.A && ch <= CharacterCodes.Z) {
+            col2 = (col2 - 64) * 26;
+            pos++;
+            continue;
+        }
+        else if (ch >= CharacterCodes.A && ch <= CharacterCodes.Z) {
+            col2 = (col2 - 96) * 26;
+            pos++;
+            continue;
+        }
+        break;
+    }
+
+    if (pos < end && id.charCodeAt(pos) === CharacterCodes.$) {
+        pos++;
+    }
+
+    const start2 = pos;
+    while (pos < end && isDigit(id.charCodeAt(pos))) {
+        pos++;
+    }
+
+    if (start2 === pos) { return id };
+
+    // Parse row numbers
+    const row2 = Number(id.substring(start, pos));
+    if (isNaN(row2)) {
+        return id;
+    }
+
+    return pos === end ? { row1, col1, row2, col2 } : id;
+}
+
+export function createFormulaParser(): Parser<boolean, FormulaNode> {
+    const handler = createBooleanErrorHandler();
+    return createParser(createAlgebra(parseCellRef, handler), handler);
+}

--- a/packages/core/micro/src/formula.ts
+++ b/packages/core/micro/src/formula.ts
@@ -26,7 +26,7 @@ const enum CharacterCodes {
     colon = 0x3a,
 }
 
-const isDigit = (ch: number) => ch >= CharacterCodes._0 && ch <= CharacterCodes._0;
+const isDigit = (ch: number) => ch >= CharacterCodes._0 && ch <= CharacterCodes._9;
 
 function parseCellRef(id: string): Reference | string {
     let col1 = 0;
@@ -42,12 +42,12 @@ function parseCellRef(id: string): Reference | string {
     while (pos < end) {
         const ch = id.charCodeAt(pos);
         if (ch >= CharacterCodes.A && ch <= CharacterCodes.Z) {
-            col1 = (col1 - 64) * 26;
+            col1 = col1 * 26 + (ch - 64);
             pos++;
             continue;
         }
         else if (ch >= CharacterCodes.a && ch <= CharacterCodes.z) {
-            col1 = (col1 - 96) * 26;
+            col1 = col1 * 26 + (ch - 96);
             pos++;
             continue;
         }
@@ -71,7 +71,7 @@ function parseCellRef(id: string): Reference | string {
         return id;
     }
 
-    if (pos === end) { return { row1, col1 } }
+    if (pos === end) { return { row1: row1 - 1, col1: col1 - 1 } }
 
     if (pos < end && id.charCodeAt(pos) !== CharacterCodes.colon) {
         return id;
@@ -88,12 +88,12 @@ function parseCellRef(id: string): Reference | string {
     while (pos < end) {
         const ch = id.charCodeAt(pos);
         if (ch >= CharacterCodes.A && ch <= CharacterCodes.Z) {
-            col2 = (col2 - 64) * 26;
+            col2 = col2 * 26 + (ch - 64);
             pos++;
             continue;
         }
         else if (ch >= CharacterCodes.a && ch <= CharacterCodes.z) {
-            col2 = (col2 - 96) * 26;
+            col2 = col2 * 26 + (ch - 96);
             pos++;
             continue;
         }
@@ -112,12 +112,12 @@ function parseCellRef(id: string): Reference | string {
     if (start2 === pos) { return id };
 
     // Parse row numbers
-    const row2 = Number(id.substring(start, pos));
+    const row2 = Number(id.substring(start2, pos));
     if (isNaN(row2)) {
         return id;
     }
 
-    return pos === end ? { row1, col1, row2, col2 } : id;
+    return pos === end ? { row1: row1 - 1, col1: col1 - 1, row2: row2 - 1, col2: col2 - 1 } : id;
 }
 
 export function createFormulaParser(): Parser<boolean, FormulaNode> {

--- a/packages/core/micro/src/functions.ts
+++ b/packages/core/micro/src/functions.ts
@@ -91,22 +91,14 @@ const average: CalcFun<unknown> = (runtime, origin, args) => {
 const max: CalcFun<unknown> = (runtime, origin, args) => {
     if (args.length === 0) { return 0; }
     const maxs = args.map((arg) => extractNumberFromProperty(runtime, origin, arg, "max"));
-    for (const arg of maxs) {
-        if (typeof arg !== "number") {
-            return arg;
-        }
-    }
+    if (typeof maxs[0] !== "number") { return maxs[0] };
     return reduceNumbers(maxs, (prev, current) => current > prev ? current : prev, maxs[0] as number);
 };
 
 const min: CalcFun<unknown> = (runtime, origin, args) => {
     if (args.length === 0) { return 0; }
     const mins = args.map((arg) => extractNumberFromProperty(runtime, origin, arg, "min"));
-    for (const arg of mins) {
-        if (typeof arg !== "number") {
-            return arg;
-        }
-    }
+    if (typeof mins[0] !== "number") { return mins[0] };
     return reduceNumbers(mins, (prev, current) => current < prev ? current : prev, mins[0] as number);
 };
 

--- a/packages/core/micro/src/functions.ts
+++ b/packages/core/micro/src/functions.ts
@@ -1,0 +1,121 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    CalcFun,
+    CalcValue,
+    errors,
+    Primitive,
+    Runtime,
+} from "@tiny-calc/nano";
+
+/*
+ * Function implementations.
+ * These are mostly reducer wrappers around Range aggregations.
+ */
+
+type PrimitiveMap = {
+    number: number;
+    string: string;
+    boolean: boolean;
+}
+
+function extractTypeFromProperty<K extends keyof PrimitiveMap>(
+    type: K, defaultValue: PrimitiveMap[K]
+): <O, Delay>(runtime: Runtime<Delay>, origin: O, arg: CalcValue<O>, property: string) => PrimitiveMap[K] | Delay | CalcValue<O>;
+
+
+function extractTypeFromProperty(
+    type: keyof PrimitiveMap,
+    defaultValue: Primitive
+): <O, Delay>(runtime: Runtime<Delay>, origin: O, arg: CalcValue<O>, property: string) => Primitive | Delay | CalcValue<O> {
+    return <O, Delay>(runtime: Runtime<Delay>, origin: O, arg: CalcValue<O>, property: string) => {
+        if (typeof arg === type) { return arg; } // fast path
+        switch (typeof arg) {
+            case "object":
+                return runtime.read(origin, arg, property, arg);
+            default:
+                return defaultValue;
+        }
+    }
+}
+
+const extractNumberFromProperty = extractTypeFromProperty("number", 0);
+const extractStringFromProperty = extractTypeFromProperty("string", "");
+
+function reduceType<K extends keyof PrimitiveMap>(type: K): <O, Delay>(args: (Delay | CalcValue<O>)[], fn: (prev: PrimitiveMap[K], current: PrimitiveMap[K]) => PrimitiveMap[K], init: PrimitiveMap[K]) => PrimitiveMap[K] | CalcValue<O> | Delay;
+function reduceType<K extends keyof PrimitiveMap>(type: K): <O, Delay>(args: (Delay | CalcValue<O>)[], fn: (prev: Primitive, current: Primitive) => Primitive, init: Primitive) => Primitive | CalcValue<O> | Delay {
+    return <O, Delay>(args: (CalcValue<O> | Delay)[], fn: (prev: Primitive, current: Primitive) => Primitive, init: Primitive) => {
+        let total = init;
+        for (const arg of args) {
+            if (typeof arg !== type) {
+                return arg;
+            }
+            total = fn(total, arg as Primitive);
+        }
+        return total;
+    }
+}
+
+const reduceNumbers = reduceType("number");
+const reduceStrings = reduceType("string");
+
+const sum: CalcFun<unknown> = (runtime, origin, args) => {
+    const totals = args.map((arg) => extractNumberFromProperty(runtime, origin, arg, "sum"));
+    return reduceNumbers(totals, (prev, current) => prev + current, 0);
+};
+
+const product: CalcFun<unknown> = (runtime, origin, args) => {
+    const totals = args.map((arg) => extractNumberFromProperty(runtime, origin, arg, "product"));
+    return reduceNumbers(totals, (prev, current) => prev * current, 1);
+};
+
+const count: CalcFun<unknown> = (runtime, origin, args) => {
+    const totals = args.map((arg) => extractNumberFromProperty(runtime, origin, arg, "count"));
+    return reduceNumbers(totals, (prev, current) => prev + current, 0);
+};
+
+const average: CalcFun<unknown> = (runtime, origin, args) => {
+    const totals = args.map((arg) => extractNumberFromProperty(runtime, origin, arg, "sum"));
+    const counts = args.map((arg) => extractNumberFromProperty(runtime, origin, arg, "count"));
+    const total = reduceNumbers(totals, (prev, current) => prev + current, 0);
+    if (typeof total === "number") {
+        const count = reduceNumbers(counts, (prev, current) => prev + current, 0);
+        return typeof count === "number" ? count === 0 ? errors.div0 : total / count : count;
+    }
+    return total;
+};
+
+const max: CalcFun<unknown> = (runtime, origin, args) => {
+    if (args.length === 0) { return 0; }
+    const maxs = args.map((arg) => extractNumberFromProperty(runtime, origin, arg, "max"));
+    for (const arg of maxs) {
+        if (typeof arg !== "number") {
+            return arg;
+        }
+    }
+    return reduceNumbers(maxs, (prev, current) => current > prev ? current : prev, maxs[0] as number);
+};
+
+const min: CalcFun<unknown> = (runtime, origin, args) => {
+    if (args.length === 0) { return 0; }
+    const mins = args.map((arg) => extractNumberFromProperty(runtime, origin, arg, "min"));
+    for (const arg of mins) {
+        if (typeof arg !== "number") {
+            return arg;
+        }
+    }
+    return reduceNumbers(mins, (prev, current) => current < prev ? current : prev, mins[0] as number);
+};
+
+const concat: CalcFun<unknown> = (runtime, origin, args) => {
+    const val = args.map((arg) => extractStringFromProperty(runtime, origin, arg, "concat"));
+    return reduceStrings(val, (prev, current) => prev + current, "");
+};
+
+export const funcs: Record<string, CalcFun<unknown>> = {
+    sum, product, count, average, max, min, concat,
+    SUM: sum, PRODUCT: product, COUNT: count, AVERAGE: average, MAX: max, MIN: min, CONCAT: concat,
+};

--- a/packages/core/micro/src/index.ts
+++ b/packages/core/micro/src/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export { IMatrix } from "./matrix";
-export { ISheetlet, createSheetlet } from "./sheetlet";
+export { IMatrix } from "./types";
+export { createSheetlet } from "./sheetlet";

--- a/packages/core/micro/src/index.ts
+++ b/packages/core/micro/src/index.ts
@@ -3,5 +3,5 @@
  * Licensed under the MIT License.
  */
 
-export { IMatrix } from "./types";
-export { createSheetlet } from "./sheetlet";
+export { IGrid, IMatrix } from "./types";
+export { createSheetletProducer, createSheetlet, ISheetlet } from "./sheetlet";

--- a/packages/core/micro/src/matrix.ts
+++ b/packages/core/micro/src/matrix.ts
@@ -1,3 +1,8 @@
+import {
+    IMatrixProducer,
+    IMatrixReader,
+} from "@tiny-calc/nano";
+
 import { IMatrix } from "./types";
 
 const enum CONSTS {
@@ -214,5 +219,22 @@ export function createMatrix<T>(): IMatrix<T> {
         clear(row: number, col: number) {
             clearCell(row, col, cells);
         },
+    }
+}
+
+export function matrixProducer<T>(data: T[][]): IMatrixProducer<T | undefined> & IMatrixReader<T | undefined> & IMatrix<T> {
+    const grid = createMatrix<T>();
+    for (let i = 0; i < data.length; i++) {
+        const row = data[i];
+        for (let j = 0; j < row.length; j++) {
+            grid.write(i, j, row[j]);
+        }
+    }
+    return {
+        numRows: data.length,
+        numCols: data.length > 0 ? data[0].length : 0,
+        ...grid,
+        removeMatrixConsumer() { },
+        openMatrix() { return this },
     }
 }

--- a/packages/core/micro/src/matrix.ts
+++ b/packages/core/micro/src/matrix.ts
@@ -3,7 +3,7 @@ import {
     IMatrixReader,
 } from "@tiny-calc/nano";
 
-import { IMatrix } from "./types";
+import { IGrid } from "./types";
 
 const enum CONSTS {
     LOGW = 4,
@@ -236,7 +236,7 @@ function initGrid<T>(): SparseGrid<T> {
     return [];
 }
 
-export function createMatrix<T>(): IMatrix<T> {
+export function createGrid<T>(): IGrid<T> {
     const cells: SparseGrid<T> = initGrid();
     return {
         read(row: number, col: number) {
@@ -254,8 +254,8 @@ export function createMatrix<T>(): IMatrix<T> {
     }
 }
 
-export function matrixProducer<T>(data: T[][]): IMatrixProducer<T | undefined> & IMatrixReader<T | undefined> & IMatrix<T> {
-    const grid = createMatrix<T>();
+export function matrixProducer<T>(data: T[][]): IMatrixProducer<T | undefined> & IMatrixReader<T | undefined> & IGrid<T> {
+    const grid = createGrid<T>();
     for (let i = 0; i < data.length; i++) {
         const row = data[i];
         for (let j = 0; j < row.length; j++) {

--- a/packages/core/micro/src/matrix.ts
+++ b/packages/core/micro/src/matrix.ts
@@ -1,63 +1,218 @@
-import { Primitive } from "@tiny-calc/nano";
+import { IMatrix } from "./types";
 
-export interface IMatrix {
-   readonly numRows: number;
-   readonly numCols: number;
-   loadCellText: (row: number, col: number) => Primitive | undefined;
-   loadCellData: (row: number, col: number) => object | undefined;
-   storeCellData: (row: number, col: number, value: object | undefined) => void;
+const enum CONSTS {
+    LOGW = 4,
+    LOGH = 5,
+    W = 1 << LOGW,
+    H = 1 << LOGH,
+    MW = W - 1,
+    MH = H - 1,
+    SIZEW = 1 << (4 * LOGW),
+    SIZEH = 1 << (4 * LOGH),
 }
 
-/** Convert a 0-based column index into an Excel-like column name (e.g., 0 -> 'A') */
-export function c0ToName(colIndex: number) {
-    let name = "";
+type CellTile<T> = T[]
 
-    do {
-        const mod = colIndex % 26;
-        name = `${String.fromCharCode(65 + mod)}${name}`;
-        // tslint:disable-next-line:no-parameter-reassignment
-        colIndex = Math.trunc(colIndex / 26) - 1;
-    } while (colIndex >= 0);
+type SparseGrid<T> = CellTile<T>[][][];
 
-    return name;
+export function getCell<T>(r: number, c: number, grid: SparseGrid<T>): T | undefined {
+    if (r < 0 || c < 0 || r >= CONSTS.SIZEH || c >= CONSTS.SIZEW) {
+        return undefined;
+    }
+    const t2 = grid[(((c >> (3 * CONSTS.LOGW)) & CONSTS.MW) << CONSTS.LOGH) | ((r >> (3 * CONSTS.LOGH)) & CONSTS.MH)];
+    if (t2) {
+        const t3 = t2[(((c >> (2 * CONSTS.LOGW)) & CONSTS.MW) << CONSTS.LOGH) | ((r >> (2 * CONSTS.LOGH)) & CONSTS.MH)];
+        if (t3) {
+            const t4 = t3[(((c >> CONSTS.LOGW) & CONSTS.MW) << CONSTS.LOGH) | ((r >> CONSTS.LOGH) & CONSTS.MH)];
+            if (t4) {
+                return t4[((c & CONSTS.MW) << CONSTS.LOGH) | (r & CONSTS.MH)];
+            }
+        }
+    }
+    return undefined;
 }
 
-export class Matrix implements IMatrix {
-    private readonly cells: { text?: Primitive, data?: object }[];
-
-    constructor(
-        public readonly numRows: number,
-        public readonly numCols: number,
-        cells = new Array(numRows * numCols),
-    ) { 
-        this.cells = cells.map(text => { return { text }});
+export function setCell<T>(r: number, c: number, grid: SparseGrid<T>, value: T) {
+    if (r < 0 || c < 0 || r >= CONSTS.SIZEH || c >= CONSTS.SIZEW) {
+        return;
     }
 
-    loadCellText(row: number, col: number) {
-        this.vetPoint(row, col);
-        return this.cells[this.rc0ToIndex(row, col)].text
-    }
-    
-    storeCellText(row: number, col: number, value: Primitive | undefined) {
-        this.vetPoint(row, col);
-        this.cells[this.rc0ToIndex(row, col)].text = value;
-    }
-    
-    loadCellData(row: number, col: number) {
-        this.vetPoint(row, col);
-        return this.cells[this.rc0ToIndex(row, col)].data;
+    const i2 = (((c >> (3 * CONSTS.LOGW)) & CONSTS.MW) << CONSTS.LOGH) | ((r >> (3 * CONSTS.LOGH)) & CONSTS.MH);
+    let t2 = grid[i2];
+    if (t2 === undefined) {
+        t2 = grid[i2] = [];
     }
 
-    storeCellData(row: number, col: number, value: object | undefined) {
-        this.vetPoint(row, col);
-        this.cells[this.rc0ToIndex(row, col)].data = value;
+    const i3 = (((c >> (2 * CONSTS.LOGW)) & CONSTS.MW) << CONSTS.LOGH) | ((r >> (2 * CONSTS.LOGH)) & CONSTS.MH);
+    let t3 = t2[i3];
+    if (t3 === undefined) {
+        t3 = t2[i3] = [];
     }
 
-    private rc0ToIndex(row: number, col: number) {
-        return row * this.numCols + col;
+    const i4 = (((c >> CONSTS.LOGW) & CONSTS.MW) << CONSTS.LOGH) | ((r >> CONSTS.LOGH) & CONSTS.MH);
+    let t4 = t3[i4];
+    if (t4 === undefined) {
+        t4 = t3[i4] = [];
+    }
+    t4[((c & CONSTS.MW) << CONSTS.LOGH) | (r & CONSTS.MH)] = value;
+}
+
+export function clearCell<T>(r: number, c: number, grid: SparseGrid<T>) {
+    if (r < 0 || c < 0 || r >= CONSTS.SIZEH || c >= CONSTS.SIZEW) {
+        return;
     }
 
-    private vetPoint(row: number, col: number) {
-        if (!(0 <= row && row < this.numRows && 0 <= col && col <= this.numCols)) { throw new Error(); }
+    const i2 = (((c >> (3 * CONSTS.LOGW)) & CONSTS.MW) << CONSTS.LOGH) | ((r >> (3 * CONSTS.LOGH)) & CONSTS.MH);
+    const t2 = grid[i2];
+    if (t2 === undefined) {
+        return;
+    }
+
+    const i3 = (((c >> (2 * CONSTS.LOGW)) & CONSTS.MW) << CONSTS.LOGH) | ((r >> (2 * CONSTS.LOGH)) & CONSTS.MH);
+    const t3 = t2[i3];
+    if (t3 === undefined) {
+        return;
+    }
+
+    const i4 = (((c >> CONSTS.LOGW) & CONSTS.MW) << CONSTS.LOGH) | ((r >> CONSTS.LOGH) & CONSTS.MH);
+    const t4 = t3[i4];
+    if (t4 === undefined) {
+        return;
+    }
+    delete t4[((c & CONSTS.MW) << CONSTS.LOGH) | (r & CONSTS.MH)];
+}
+
+export function forEachCell<T>(grid: SparseGrid<T>, cb: (r: number, c: number, value: T) => void): void {
+    let i1 = 0;
+    for (const t1 of grid) {
+        if (t1 !== undefined) {
+            let i2 = 0;
+            const c1 = (i1 >> CONSTS.LOGH) << (3 * CONSTS.LOGW);
+            const r1 = (i1 & CONSTS.MH) << (3 * CONSTS.LOGH);
+            for (const t2 of t1) {
+                if (t2 !== undefined) {
+                    let i3 = 0;
+                    const c2 = (i2 >> CONSTS.LOGH) << (2 * CONSTS.LOGW);
+                    const r2 = (i2 & CONSTS.MH) << (2 * CONSTS.LOGH);
+                    for (const t3 of t2) {
+                        if (t3 !== undefined) {
+                            let i4 = 0;
+                            const c3 = (i3 >> CONSTS.LOGH) << CONSTS.LOGW;
+                            const r3 = (i3 & CONSTS.MH) << CONSTS.LOGH;
+                            for (const value of t3) {
+                                if (value !== undefined) {
+                                    cb(r1 | r2 | r3 | i4 & CONSTS.MH, c1 | c2 | c3 | i4 >> CONSTS.LOGH, value);
+                                }
+                                i4++;
+                            }
+                        }
+                        i3++;
+                    }
+                }
+                i2++;
+            }
+        }
+        i1++;
+    }
+}
+
+export function forEachCellInColumn<T>(grid: SparseGrid<T>, column: number, cb: (r: number, c: number, value: T) => void): void {
+    const colIdx1 = colIdx(column, 3);
+    const colIdx2 = colIdx(column, 2);
+    const colIdx3 = colIdx(column, 1);
+    const colIdx4 = colIdx(column, 0);
+    for (let r1 = 0; r1 < CONSTS.H; r1++) {
+        const t1 = grid[colIdx1 | r1];
+        if (t1 === undefined) { continue; }
+        for (let r2 = 0; r2 < CONSTS.H; r2++) {
+            const t2 = t1[colIdx2 | r2];
+            if (t2 === undefined) { continue; }
+            for (let r3 = 0; r3 < CONSTS.H; r3++) {
+                const t3 = t2[colIdx3 | r3];
+                if (t3 === undefined) { continue; }
+                for (let r4 = 0; r4 < CONSTS.H; r4++) {
+                    const cell = t3[colIdx4 | r4];
+                    if (cell === undefined) { continue; }
+                    cb(
+                        (r1 & CONSTS.MH) << (3 * CONSTS.LOGH) |
+                        (r2 & CONSTS.MH) << (2 * CONSTS.LOGH) |
+                        (r3 & CONSTS.MH) << CONSTS.LOGH |
+                        r4 & CONSTS.MH,
+                        column, cell as any
+                    );
+                }
+            }
+        }
+    }
+}
+
+function colIdx(col: number, level: 0 | 1 | 2 | 3): number {
+    return ((col >> (level * CONSTS.LOGW)) & CONSTS.MW) << CONSTS.LOGH;
+}
+
+function colIdxUnshifted(col: number, level: 0 | 1 | 2 | 3): number {
+    return ((col >> (level * CONSTS.LOGW)) & CONSTS.MW);
+}
+
+export function forEachCellInColumns<T>(grid: SparseGrid<T>, columnStart: number, numCols: number, cb: (r: number, c: number, value: T) => void): void {
+    const colEnd = columnStart + numCols - 1;
+    for (let r1 = 0; r1 < CONSTS.H; r1++) {
+        const cStart1 = colIdxUnshifted(columnStart, 3);
+        const cEnd1 = colIdxUnshifted(colEnd, 3);
+        for (let c1 = cStart1; c1 <= cEnd1; c1++) {
+            const t1 = grid[(c1 << CONSTS.LOGH) | r1];
+            if (t1 === undefined) { continue; }
+            for (let r2 = 0; r2 < CONSTS.H; r2++) {
+                const cStart2 = colIdxUnshifted(columnStart, 2);
+                const cEnd2 = colIdxUnshifted(colEnd, 2);
+                for (let c2 = cStart2; c2 <= cEnd2; c2++) {
+                    const t2 = t1[(c2 << CONSTS.LOGH) | r2];
+                    if (t2 === undefined) { continue; }
+                    for (let r3 = 0; r3 < CONSTS.H; r3++) {
+                        const cStart3 = colIdxUnshifted(columnStart, 1);
+                        const cEnd3 = colIdxUnshifted(colEnd, 1);
+                        for (let c3 = cStart3; c3 <= cEnd3; c3++) {
+                            const t3 = t2[(c3 << CONSTS.LOGH) | r3];
+                            if (t3 === undefined) { continue; }
+                            for (let r4 = 0; r4 < CONSTS.H; r4++) {
+                                const cStart4 = colIdxUnshifted(columnStart, 0);
+                                const cEnd4 = colIdxUnshifted(colEnd, 0);
+                                for (let c4 = cStart4; c4 <= cEnd4; c4++) {
+                                    const cell = t3[(c4 << CONSTS.LOGH) | r4];
+                                    if (cell === undefined) { continue; }
+                                    cb(
+                                        (r1 & CONSTS.MH) << (3 * CONSTS.LOGH) |
+                                        (r2 & CONSTS.MH) << (2 * CONSTS.LOGH) |
+                                        (r3 & CONSTS.MH) << CONSTS.LOGH |
+                                        r4 & CONSTS.MH,
+                                        (c1 << (3 * CONSTS.LOGW)) | (c2 << (2 * CONSTS.LOGW)) | (c3 << CONSTS.LOGW) | c4,
+                                        cell
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+function initGrid<T>(): SparseGrid<T> {
+    return [];
+}
+
+export function createMatrix<T>(): IMatrix<T> {
+    const cells: SparseGrid<T> = initGrid();
+    return {
+        read(row: number, col: number) {
+            return getCell(row, col, cells);
+        },
+        write(row: number, col: number, value: T) {
+            setCell(row, col, cells, value);
+        },
+        clear(row: number, col: number) {
+            clearCell(row, col, cells);
+        },
     }
 }

--- a/packages/core/micro/src/matrix.ts
+++ b/packages/core/micro/src/matrix.ts
@@ -62,6 +62,35 @@ export function setCell<T>(r: number, c: number, grid: SparseGrid<T>, value: T) 
     t4[((c & CONSTS.MW) << CONSTS.LOGH) | (r & CONSTS.MH)] = value;
 }
 
+export function getOrSetCell<T>(r: number, c: number, grid: SparseGrid<T>, value: () => T): T | undefined {
+    if (r < 0 || c < 0 || r >= CONSTS.SIZEH || c >= CONSTS.SIZEW) {
+        return;
+    }
+
+    const i2 = (((c >> (3 * CONSTS.LOGW)) & CONSTS.MW) << CONSTS.LOGH) | ((r >> (3 * CONSTS.LOGH)) & CONSTS.MH);
+    let t2 = grid[i2];
+    if (t2 === undefined) {
+        t2 = grid[i2] = [];
+    }
+
+    const i3 = (((c >> (2 * CONSTS.LOGW)) & CONSTS.MW) << CONSTS.LOGH) | ((r >> (2 * CONSTS.LOGH)) & CONSTS.MH);
+    let t3 = t2[i3];
+    if (t3 === undefined) {
+        t3 = t2[i3] = [];
+    }
+
+    const i4 = (((c >> CONSTS.LOGW) & CONSTS.MW) << CONSTS.LOGH) | ((r >> CONSTS.LOGH) & CONSTS.MH);
+    let t4 = t3[i4];
+    if (t4 === undefined) {
+        t4 = t3[i4] = [];
+    }
+    const idx = ((c & CONSTS.MW) << CONSTS.LOGH) | (r & CONSTS.MH);
+    if (t4[idx] === undefined) {
+        return t4[idx] = value();
+    }
+    return t4[idx];
+}
+
 export function clearCell<T>(r: number, c: number, grid: SparseGrid<T>) {
     if (r < 0 || c < 0 || r >= CONSTS.SIZEH || c >= CONSTS.SIZEW) {
         return;
@@ -215,6 +244,9 @@ export function createMatrix<T>(): IMatrix<T> {
         },
         write(row: number, col: number, value: T) {
             setCell(row, col, cells, value);
+        },
+        readOrWrite(row: number, col: number, value: () => T) {
+            return getOrSetCell(row, col, cells, value);
         },
         clear(row: number, col: number) {
             clearCell(row, col, cells);

--- a/packages/core/micro/src/range.ts
+++ b/packages/core/micro/src/range.ts
@@ -50,7 +50,7 @@ export function runFunc<Res extends CellValue>(fiber: FunctionFiber<Res>) {
         const content = context.read(row, j);
         if (isPendingTask(content)) {
             fiber.column = j;
-            return context.cache[makeCacheKey(range, fiber.flag)] = { kind: "Pending" as const, fiber };
+            return context.cache[makeCacheKey(range, fiber.state)] = { kind: "Pending" as const, fiber };
         }
         run(content);
     }
@@ -60,12 +60,12 @@ export function runFunc<Res extends CellValue>(fiber: FunctionFiber<Res>) {
             if (isPendingTask(content)) {
                 fiber.row = i;
                 fiber.column = j;
-                return context.cache[makeCacheKey(range, fiber.flag)] = { kind: "Pending" as const, fiber };
+                return context.cache[makeCacheKey(range, fiber.state)] = { kind: "Pending" as const, fiber };
             }
             run(content);
         }
     }
-    return context.cache[makeCacheKey(range, fiber.flag)] = finish(runner[0]);
+    return context.cache[makeCacheKey(range, fiber.state)] = finish(runner[0]);
 }
 
 

--- a/packages/core/micro/src/range.ts
+++ b/packages/core/micro/src/range.ts
@@ -1,0 +1,200 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import {
+    CalcObj,
+    CalcValue,
+    Pending,
+    TypeMap,
+    TypeName,
+} from "@tiny-calc/nano";
+
+import {
+    errors,
+    isPending,
+    makePendingFunction,
+} from "./core";
+
+
+import {
+    FunctionFiber,
+    Range,
+    RangeContext,
+} from "./types";
+
+/*
+ * Function Runners are accumulators over ranges.
+ */
+
+type FunctionRunner<Res> = [Res, (x: unknown) => void];
+
+const createRunner = <Res>(fn: (box: [Res]) => (x: unknown) => void) => {
+    return (init: Res) => {
+        const result: FunctionRunner<Res> = [init, undefined!];
+        result[1] = fn(result as unknown as [Res]);
+        return result;
+    };
+};
+
+const createSum = createRunner<number>(result => n => { if (typeof n === "number") { result[0] += n; } });
+
+const createProduct = createRunner<number>(result => n => { if (typeof n === "number") { result[0] *= n; } });
+
+const createCount = createRunner<number>(result => n => { if (typeof n === "number") { result[0]++; } });
+
+const createAverage = createRunner<[number, number]>(result => n => { if (typeof n === "number") { result[0][0] += n; result[0][1]++; } });
+
+const createMax = createRunner<number | undefined>(
+    result => n => {
+        if (typeof n === "number" && (result[0] === undefined || n > result[0])) {
+            result[0] = n;
+        }
+    },
+);
+
+const createMin = createRunner<number | undefined>(
+    result => n => {
+        if (typeof n === "number" && (result[0] === undefined || n < result[0])) {
+            result[0] = n;
+        }
+    },
+);
+
+const createConcat = createRunner<string>((result) => s => { if (typeof s === "string") { result[0] += s; } });
+
+/*
+ * Core aggregation functions over ranges
+ */
+
+type RangeAggregation<R, Accum = R> = (range: Range, context: RangeContext, someTask?: FunctionFiber<Accum>) => R | FunctionFiber<Accum>;
+
+function runFunc<Res>(context: RangeContext, task: FunctionFiber<Res>, initRunner: (init: Res) => FunctionRunner<Res>) {
+    const { current, row, column, range } = task;
+    const runner = initRunner(current);
+    const run = runner[1];
+    const endR = row + range.height;
+    const endC = column + range.width;
+    // TODO: This is not resumable! See function fiber for how to do
+    // this properly.
+    for (let i = row; i < endR; i += 1) {
+        for (let j = column; j < endC; j += 1) {
+            const content = context.link(i, j);
+            if (isPending(content)) {
+                task.row = i;
+                task.column = j;
+                task.current = runner[0];
+                return task;
+            }
+            run(content);
+        }
+    }
+    return runner[0];
+}
+
+const rangeSum: RangeAggregation<number> = (range, context, someTask?) => {
+    const task = someTask || makePendingFunction("sum", range, range.tlRow, range.tlCol, 0);
+    return runFunc(context, task, createSum);
+};
+
+const rangeProduct: RangeAggregation<number> = (range, context, someTask?) => {
+    const task = someTask || makePendingFunction("product", range, range.tlRow, range.tlCol, 1);
+    return runFunc(context, task, createProduct);
+};
+
+const rangeCount: RangeAggregation<number> = (range, context, someTask?) => {
+    const task = someTask || makePendingFunction("count", range, range.tlRow, range.tlCol, 0);
+    return runFunc(context, task, createCount);
+};
+
+const rangeAverage: RangeAggregation<number | CalcObj<unknown>, [number, number]> = (range, context, someTask?) => {
+    const task = someTask || makePendingFunction("average", range, range.tlRow, range.tlCol, [0, 0]);
+    const result = runFunc(context, task, createAverage);
+    if (isPending(result)) { return result; }
+    const [total, finalCount] = result;
+    return finalCount === 0 ? errors.div0 : total / finalCount;
+};
+
+const rangeMax: RangeAggregation<number, number | undefined> = (range, context, someTask?) => {
+    const task = someTask || makePendingFunction("max", range, range.tlRow, range.tlCol, undefined);
+    const result = runFunc(context, task, createMax);
+    return result === undefined ? 0 : result;
+};
+
+const rangeMin: RangeAggregation<number, number | undefined> = (range, context, someTask?) => {
+    const task = someTask || makePendingFunction("min", range, range.tlRow, range.tlCol, undefined);
+    const result = runFunc(context, task, createMin);
+    return result === undefined ? 0 : result;
+};
+
+const rangeConcat: RangeAggregation<string> = (range, context, someTask?) => {
+    const task = someTask || makePendingFunction("concat", range, range.tlRow, range.tlCol, "");
+    return runFunc(context, task, createConcat);
+};
+
+type FreshAggregation<R, Accum = R> = (range: Range, context: RangeContext) => R | FunctionFiber<Accum>;
+
+const aggregations: Record<string, FreshAggregation<CalcValue<unknown>, unknown>> = {
+    sum: rangeSum, product: rangeProduct, count: rangeCount, average: rangeAverage, max: rangeMax, min: rangeMin, concat: rangeConcat,
+    SUM: rangeSum, PRODUCT: rangeProduct, COUNT: rangeCount, AVERAGE: rangeAverage, MAX: rangeMax, MIN: rangeMin, CONCAT: rangeConcat,
+};
+
+const serialiseRange = () => "REF";
+
+const rangeTypeMap: TypeMap<Range, RangeContext> = {
+    [TypeName.Readable]: {
+        read: (receiver: Range, message: string, context: RangeContext): CalcValue<RangeContext> | Pending<CalcValue<RangeContext>> => {
+            if (aggregations[message] !== undefined) {
+                const fn = aggregations[message as keyof typeof aggregations];
+                return fn(receiver, context);
+            }
+            switch (message) {
+                case "row":
+                case "ROW":
+                    return receiver.tlRow + 1;
+                case "column":
+                case "COLUMN":
+                    return receiver.tlCol + 1;
+                default:
+                    const value = context.link(receiver.tlRow, receiver.tlCol);
+                    if (typeof value === "object") {
+                        if (isPending(value)) {
+                            return value;
+                        }
+                        const reader = value.typeMap()[TypeName.Readable];
+                        if (reader) {
+                            return reader.read(value, message, context);
+                        }
+                    }
+                    return errors.unknownField;
+
+            }
+        }
+    },
+    [TypeName.Reference]: {
+        dereference: (value: Range, context: RangeContext) => context.link(value.tlRow, value.tlCol)
+    }
+}
+
+const getRangeType = () => rangeTypeMap;
+
+export const isRange = (v: { typeMap: () => unknown; }): v is Range => {
+    return v.typeMap() === rangeTypeMap;
+}
+
+/**
+ * A Range represents a view of the grid that knows how to calculate
+ * aggregations over the view. The canonical value of a Range is the
+ * top left corner.
+ */
+export function makeRange(firstR: number, firstC: number, secondR: number, secondC: number): Range {
+    return {
+        tlRow: firstR < secondR ? firstR : secondR,
+        tlCol: firstC < secondC ? firstC : secondC,
+        height: Math.abs(firstR - secondR) + 1,
+        width: Math.abs(firstC - secondC) + 1,
+        serialise: serialiseRange,
+        typeMap: getRangeType,
+    }
+}

--- a/packages/core/micro/src/types.ts
+++ b/packages/core/micro/src/types.ts
@@ -1,13 +1,20 @@
 import {
-    Primitive,
+    ExpressionNode,
     CalcObj,
     CalcValue,
-    Formula,
+    Primitive,
 } from "@tiny-calc/nano";
 
 export type Point = [number, number];
 
-export type Value = Primitive | undefined;
+export interface Reference {
+    row1: number;
+    col1: number;
+    row2?: number | undefined;
+    col2?: number | undefined;
+}
+
+export type FormulaNode = ExpressionNode<string | Reference>;
 
 /*
  * Cell Data Types
@@ -25,7 +32,7 @@ export const enum CalcFlag {
 
 export type CellValue = CalcValue<RangeContext>;
 
-export interface  ValueCell {
+export interface ValueCell {
     flag: CalcFlag.Clean;
     content: Primitive;
 }
@@ -34,7 +41,7 @@ export interface FormulaCell {
     flag: CalcFlag;
     content: string;
     value: CellValue | undefined;
-    fn: Formula | undefined;
+    fn: FormulaNode | undefined;
     prev: FormulaCell | undefined;
     next: FormulaCell | undefined;
 }
@@ -60,8 +67,7 @@ export interface PendingValue {
 
 export interface RangeContext {
     origin: Point | undefined;
-    link: (row: number, col: number) => CalcValue<RangeContext> | PendingValue;
-    parseRef: (text: string) => Point | undefined;
+    read: (row: number, col: number) => CalcValue<RangeContext> | PendingValue;
 }
 
 export interface Range extends CalcObj<RangeContext> {
@@ -71,6 +77,9 @@ export interface Range extends CalcObj<RangeContext> {
     readonly width: number;
 }
 
+/**
+ * IMatrix denotes a 2D cache for values of type `T`.
+ */
 export interface IMatrix<T> {
     read(row: number, col: number): T | undefined;
     write(row: number, col: number, value: T): void;

--- a/packages/core/micro/src/types.ts
+++ b/packages/core/micro/src/types.ts
@@ -26,8 +26,8 @@ export type FormulaNode = ExpressionNode<string | Reference>;
 export const enum CalcFlag {
     Clean,
     Dirty,
-    Enqueued,
     InCalc,
+    CleanUnacked,
 }
 
 export type Value = Primitive | undefined;
@@ -39,30 +39,35 @@ export interface ValueCell {
     content: Primitive;
 }
 
-export interface FormulaCell {
+interface FiberBase<T> {
+  flag: number | string;
+  prev: Fiber<T> | undefined;
+  next: Fiber<T> | undefined;
+}
+
+export interface FormulaCell<T> extends FiberBase<T> {
     flag: CalcFlag;
     row: number;
     col: number;
     formula: string;
-    value: CellValue | undefined;
+    value: T | undefined;
     node: FormulaNode | undefined;
-    prev: FormulaCell | undefined;
-    next: FormulaCell | undefined;
 }
 
-export type Cell = ValueCell | FormulaCell;
-
-export type Fiber<T> = FormulaCell | FunctionFiber<T>;
-
-export type FunctionTask = "sum" | "product" | "count" | "average" | "max" | "min" | "concat";
-
-export interface FunctionFiber<T> {
+export interface FunctionFiber<T> extends FiberBase<T> {
     flag: FunctionTask;
     range: Range;
     row: number;
     column: number;
     current: T;
 }
+
+export type Cell = ValueCell | FormulaCell<CellValue>;
+
+export type Fiber<T> = FormulaCell<T> | FunctionFiber<T>;
+
+export type FunctionTask = "sum" | "product" | "count" | "average" | "max" | "min" | "concat";
+
 
 export interface PendingTask<T> {
     kind: "Pending";

--- a/packages/core/micro/src/types.ts
+++ b/packages/core/micro/src/types.ts
@@ -1,5 +1,11 @@
+import {
+    Primitive,
+} from "@tiny-calc/nano";
+
 export interface IMatrix<T> {
     read(row: number, col: number): T | undefined;
     write(row: number, col: number, value: T): void;
     clear(row: number, col: number): void;
 }
+
+export type Value = Primitive | undefined;

--- a/packages/core/micro/src/types.ts
+++ b/packages/core/micro/src/types.ts
@@ -28,6 +28,7 @@ export const enum CalcFlag {
     Dirty,
     InCalc,
     CleanUnacked,
+    Invalid,
 }
 
 export type Value = Primitive | undefined;
@@ -48,7 +49,6 @@ export interface FormulaCell<T> {
     node: FormulaNode | undefined;
 }
 
-// Keep calling accum (that updates the state), then run the finaliser.
 export type FunctionRunner<A, R> = [A, (accum: unknown) => void, (finalise: A) => R];
 
 declare const function_skolem: unique symbol;
@@ -77,6 +77,7 @@ export interface PendingTask<T> {
 export type PendingValue = PendingTask<CalcValue<RangeContext>>;
 
 export interface RangeContext {
+    /** Cache for aggregations */
     cache: Record<string, PendingValue | CellValue | undefined>;
     origin: Point | undefined;
     read: (row: number, col: number) => CellValue | PendingTask<CellValue>;

--- a/packages/core/micro/src/types.ts
+++ b/packages/core/micro/src/types.ts
@@ -1,0 +1,5 @@
+export interface IMatrix<T> {
+    read(row: number, col: number): T | undefined;
+    write(row: number, col: number, value: T): void;
+    clear(row: number, col: number): void;
+}

--- a/packages/core/micro/src/types.ts
+++ b/packages/core/micro/src/types.ts
@@ -105,12 +105,23 @@ export interface Binder {
 }
 
 /**
- * IMatrix denotes a 2D cache for values of type `T`.
+ * IGrid denotes a 2D cache for values of type `T`.
  */
-export interface IMatrix<T> {
+export interface IGrid<T> {
     read(row: number, col: number): T | undefined;
     write(row: number, col: number, value: T): void;
     // Undefined means invalid row or col.
     readOrWrite(row: number, col: number, value: () => T): T | undefined;
     clear(row: number, col: number): void;
+}
+
+/**
+ * Legacy Interface
+ */
+export interface IMatrix {
+   readonly numRows: number;
+   readonly numCols: number;
+   loadCellText: (row: number, col: number) => Primitive | undefined;
+   loadCellData: (row: number, col: number) => object | undefined;
+   storeCellData: (row: number, col: number, value: object | undefined) => void;
 }

--- a/packages/core/micro/src/types.ts
+++ b/packages/core/micro/src/types.ts
@@ -23,11 +23,10 @@ export type FormulaNode = ExpressionNode<string | Reference>;
 /**
  * CalcFlags for Cell Status.
  */
-export const enum CalcFlag {
+export const enum CalcState {
     Clean,
     Dirty,
     InCalc,
-    CleanUnacked,
     Invalid,
 }
 
@@ -36,12 +35,18 @@ export type Value = Primitive | undefined;
 export type CellValue = CalcValue<RangeContext>;
 
 export interface ValueCell {
-    flag: CalcFlag.Clean;
+    state: CalcState.Clean;
     content: Primitive;
 }
 
+export enum CalcFlags {
+    None = 0,
+    InStack = 1,
+}
+
 export interface FormulaCell<T> {
-    flag: CalcFlag;
+    state: CalcState;
+    flags: CalcFlags;
     row: number;
     col: number;
     formula: string;
@@ -55,9 +60,10 @@ declare const function_skolem: unique symbol;
 export type FunctionSkolem = typeof function_skolem;
 
 export interface FunctionFiber<R> {
-    readonly flag: FunctionTask;
+    readonly state: FunctionTask;
     readonly range: Range;
     readonly context: RangeContext,
+    flags: CalcFlags,
     row: number;
     column: number;
     readonly runner: FunctionRunner<FunctionSkolem, R>;

--- a/packages/core/micro/src/types.ts
+++ b/packages/core/micro/src/types.ts
@@ -43,6 +43,7 @@ export enum CalcFlags {
     None = 0,
     InStack = 1 << 0,
     InChain = 1 << 1,
+    PendingNotification = 1 << 2,
 }
 
 export interface FormulaCell<T> {

--- a/packages/core/micro/src/types.ts
+++ b/packages/core/micro/src/types.ts
@@ -41,7 +41,8 @@ export interface ValueCell {
 
 export enum CalcFlags {
     None = 0,
-    InStack = 1,
+    InStack = 1 << 0,
+    InChain = 1 << 1,
 }
 
 export interface FormulaCell<T> {

--- a/packages/core/micro/src/types.ts
+++ b/packages/core/micro/src/types.ts
@@ -101,6 +101,7 @@ export interface Binder {
     getVolatile: () => Set<number>;
     bindCell: (fromRow: number, fromCol: number, toRow: number, toCol: number) => void;
     getDependents: (row: number, col: number) => Set<number> | undefined;
+    clearDependents: (row: number, col: number) => void;
     clear: () => void;
 }
 

--- a/packages/core/micro/src/types.ts
+++ b/packages/core/micro/src/types.ts
@@ -1,11 +1,78 @@
 import {
     Primitive,
+    CalcObj,
+    CalcValue,
+    Formula,
 } from "@tiny-calc/nano";
+
+export type Point = [number, number];
+
+export type Value = Primitive | undefined;
+
+/*
+ * Cell Data Types
+ */
+
+/**
+ * CalcFlags for Cell Status.
+ */
+export const enum CalcFlag {
+    Clean,
+    Dirty,
+    Enqueued,
+    InCalc,
+}
+
+export type CellValue = CalcValue<RangeContext>;
+
+export interface  ValueCell {
+    flag: CalcFlag.Clean;
+    content: Primitive;
+}
+
+export interface FormulaCell {
+    flag: CalcFlag;
+    content: string;
+    value: CellValue | undefined;
+    fn: Formula | undefined;
+    prev: FormulaCell | undefined;
+    next: FormulaCell | undefined;
+}
+
+export type Cell = ValueCell | FormulaCell;
+
+export type Fiber<T = unknown> = FormulaCell | FunctionFiber<T>;
+
+export type FunctionTask = "sum" | "product" | "count" | "average" | "max" | "min" | "concat";
+
+export interface FunctionFiber<T = unknown> {
+    flag: FunctionTask;
+    range: Range;
+    row: number;
+    column: number;
+    current: T;
+}
+
+export interface PendingValue {
+    kind: "Pending";
+    fiber: Fiber;
+}
+
+export interface RangeContext {
+    origin: Point | undefined;
+    link: (row: number, col: number) => CalcValue<RangeContext> | PendingValue;
+    parseRef: (text: string) => Point | undefined;
+}
+
+export interface Range extends CalcObj<RangeContext> {
+    readonly tlRow: number;
+    readonly tlCol: number;
+    readonly height: number;
+    readonly width: number;
+}
 
 export interface IMatrix<T> {
     read(row: number, col: number): T | undefined;
     write(row: number, col: number, value: T): void;
     clear(row: number, col: number): void;
 }
-
-export type Value = Primitive | undefined;

--- a/packages/core/micro/test/formula.spec.ts
+++ b/packages/core/micro/test/formula.spec.ts
@@ -1,0 +1,28 @@
+import "mocha";
+import { strict as assert } from "assert";
+
+import {
+    ident,
+} from "@tiny-calc/nano";
+
+import { createFormulaParser } from "../src/formula";
+
+
+const parser = createFormulaParser();
+
+describe("Formula Parser", () => {
+
+    function parseTest(input: string, expected: object) {
+        const [ok, res] = parser(input);
+        assert.strictEqual(ok, true);
+        assert.strictEqual(res, expected);
+    }
+
+    it("should parse single cell refs", () => {
+        parseTest("A1", ident({ row1: 1, col1: 1 }));
+        parseTest("a1", ident({ row1: 1, col1: 1 }));
+        parseTest("Aa1", ident({ row1: 1, col1: 27 }));
+        parseTest("A1:B1", ident({ row1: 1, col1: 1, row2: 1, col2: 2 }));
+    });
+
+});

--- a/packages/core/micro/test/formula.spec.ts
+++ b/packages/core/micro/test/formula.spec.ts
@@ -13,16 +13,16 @@ const parser = createFormulaParser();
 describe("Formula Parser", () => {
 
     function parseTest(input: string, expected: object) {
-        const [ok, res] = parser(input);
-        assert.strictEqual(ok, true);
-        assert.strictEqual(res, expected);
+        const [errors, res] = parser(input);
+        assert.deepStrictEqual(errors, false);
+        assert.deepStrictEqual(res, expected);
     }
 
     it("should parse single cell refs", () => {
-        parseTest("A1", ident({ row1: 1, col1: 1 }));
-        parseTest("a1", ident({ row1: 1, col1: 1 }));
-        parseTest("Aa1", ident({ row1: 1, col1: 27 }));
-        parseTest("A1:B1", ident({ row1: 1, col1: 1, row2: 1, col2: 2 }));
+        parseTest("A1", ident({ row1: 0, col1: 0 }));
+        parseTest("a1", ident({ row1: 0, col1: 0 }));
+        parseTest("Aa1", ident({ row1: 0, col1: 26 }));
+        parseTest("A1:B1", ident({ row1: 0, col1: 0, row2: 0, col2: 1 }));
     });
 
 });

--- a/packages/core/micro/test/formula.spec.ts
+++ b/packages/core/micro/test/formula.spec.ts
@@ -18,11 +18,20 @@ describe("Formula Parser", () => {
         assert.deepStrictEqual(res, expected);
     }
 
-    it("should parse single cell refs", () => {
+    it("should parse refs ok", () => {
         parseTest("A1", ident({ row1: 0, col1: 0 }));
         parseTest("a1", ident({ row1: 0, col1: 0 }));
         parseTest("Aa1", ident({ row1: 0, col1: 26 }));
         parseTest("A1:B1", ident({ row1: 0, col1: 0, row2: 0, col2: 1 }));
+        parseTest("$A$1:$B$1", ident({ row1: 0, col1: 0, row2: 0, col2: 1 }));
+        parseTest("A1:$B$1", ident({ row1: 0, col1: 0, row2: 0, col2: 1 }));
+        parseTest("A$1:$B$1", ident({ row1: 0, col1: 0, row2: 0, col2: 1 }));
+    });
+    it("should handle size limits", () => {
+        parseTest("A1048576:B1048576", ident({ row1: 1048576 - 1, col1: 0, row2: 1048576 - 1, col2: 1 }));
+        parseTest("A1048577", ident("A1048577"));
+        parseTest("A1048576:B1048577", ident("A1048576:B1048577"));
+        parseTest("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1", ident("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1"));
     });
 
 });

--- a/packages/core/micro/test/sheetlet.spec.ts
+++ b/packages/core/micro/test/sheetlet.spec.ts
@@ -1,11 +1,17 @@
-import { CalcValue, Primitive, IMatrixReader } from "@tiny-calc/nano";
+import { CalcValue, Primitive, IMatrixConsumer, IMatrixReader } from "@tiny-calc/nano";
 import { strict as assert } from "assert";
 import "mocha";
-import { createMatrix, matrixProducer } from "../src/matrix";
-import { createSheetlet, Sheetlet } from "../src/sheetlet";
+import { createGrid, matrixProducer } from "../src/matrix";
+import { createSheetletProducer, Sheetlet } from "../src/sheetlet";
 import { makeBenchmark } from "./sheets";
 
 type Value = Primitive | undefined;
+
+const nullConsumer: IMatrixConsumer<unknown> = {
+    rowsChanged() {},
+    colsChanged() {},
+    cellsChanged() {},
+}
 
 describe("Sheetlet", () => {
     function evalCellTest(sheet: IMatrixReader<Value>, row: number, col: number, expected: Primitive) {
@@ -32,14 +38,19 @@ describe("Sheetlet", () => {
         return matrix;
     }
 
+    function initTest(values: Primitive[][]) {
+        const matrix = matrixProducer<Value>(values);
+        return [matrix, createSheetletProducer(matrix, createGrid())] as const;
+    }
+
     describe("constant", () => {
         const matrix = matrixProducer<Value>([
             [0, 1, 2, "Hello"],
             [3, 4, 5, " world"]
         ]);
 
-        const sheet = createSheetlet(matrix, createMatrix());
-        sheet.openMatrix(undefined as any);
+        const sheet = createSheetletProducer(matrix, createGrid());
+        sheet.openMatrix(nullConsumer);
 
         describe("evaluate cell", () => {
             const evalCases = [
@@ -68,7 +79,7 @@ describe("Sheetlet", () => {
 
     describe("sums 3x3 benchmark", () => {
         const { sheet, setAt } = makeBenchmark(3);
-        const reader = sheet.openMatrix(undefined as any);
+        const reader = sheet.openMatrix(nullConsumer);
 
         it("initially zero", () => {
             assert.deepEqual(
@@ -87,6 +98,145 @@ describe("Sheetlet", () => {
                 [1, 3, 8],
                 [2, 8, 26],
             ]);
+        });
+    });
+
+    describe("interactive tests", () => {
+        it("should run a simple backward chain", () => {
+            const [data, sheet] = initTest([
+                [1, 2, 3, 4, 5]
+            ]);
+            
+            const reader = sheet.openMatrix(nullConsumer);
+
+            assert.deepEqual(
+                extract(reader, 1, 5), [
+                    [1, 2, 3, 4, 5]
+                ]);
+            
+            data.write(0, 0, "=PRODUCT(B1:E1)");
+            data.write(0, 1, "=PRODUCT(C1:E1)");
+            data.write(0, 2, "=PRODUCT(D1:E1)");
+            
+            sheet.invalidate(0, 0);
+            
+            assert.deepEqual(
+                extract(reader, 1, 5), [
+                    [120, 2, 3, 4, 5]
+                ]);
+
+            sheet.invalidate(0, 1);
+
+            assert.deepEqual(
+                extract(reader, 1, 5), [
+                    [3600, 60, 3, 4, 5]
+                ]);
+
+            sheet.invalidate(0, 2);
+
+            assert.deepEqual(
+                extract(reader, 1, 5), [
+                    [160000, 400, 20, 4, 5]
+                ]);
+
+            data.write(0, 0, 10);
+            data.write(0, 4, "=A1+1");
+
+            sheet.invalidate(0, 0);
+            sheet.invalidate(0, 4);
+            
+            assert.deepEqual(
+                extract(reader, 1, 5), [
+                    [10, 1936, 44, 4, 11]
+                ]);
+            
+        });
+
+        it("should handle conditional trickery", () => {
+            const [data, sheet] = initTest([
+                [1,
+                 "=IF(A1 = 1, A1 + 1, C1 + 1)",
+                 "=IF(A1 = 1, B1 + 1, D1 + 1)",
+                 "=IF(A1 = 1, C1 + 1, E1 + 1)",
+                 "=IF(A1 = 1, D1 + 1, 10)"
+                ]
+            ]);
+            
+            const reader = sheet.openMatrix(nullConsumer);
+
+            assert.deepEqual(
+                extract(reader, 1, 5), [
+                    [1, 2, 3, 4, 5]
+                ]);
+            
+            data.write(0, 0, 2);
+            sheet.invalidate(0, 0);
+            
+            assert.deepEqual(
+                extract(reader, 1, 5), [
+                    [2, 13, 12, 11, 10]
+                ]);
+
+            data.write(0, 1, "=C1 + D1 + E1");
+            data.write(0, 4, 11);
+            sheet.invalidate(0, 1);
+            sheet.invalidate(0, 4);
+
+            assert.deepEqual(
+                extract(reader, 1, 5), [
+                    [2, 36, 13, 12, 11]
+                ]);
+        });
+
+        it("should handle conditional trickery with aggregations", () => {
+            const [data, sheet] = initTest([
+                [1,
+                 "=IF(A1 = 1, 10, SUM(C1:E1)+1)",
+                 "=IF(A1 = 1, 11, SUM(D1:E1)+1)",
+                 "=IF(A1 = 1, 12, SUM(E1:E1)+1)",
+                 "=IF(A1 = 1, 13, 100)",
+                ]
+            ]);
+            
+            const reader = sheet.openMatrix(nullConsumer);
+
+            assert.deepEqual(
+                extract(reader, 1, 5), [
+                    [1, 10, 11, 12, 13]
+                ]);
+            
+            data.write(0, 0, 55);
+            sheet.invalidate(0, 0);
+            
+            assert.deepEqual(
+                extract(reader, 1, 5), [
+                    [55, 404, 202, 101, 100]
+                ]);
+        });
+
+        it("should handle switching", () => {
+            const [data, sheet] = initTest([
+                ["=COLUMN",
+                 "=IF(A1 = 1, C1, D1)",
+                 "=IF(A1 = 1, D1, B1)",
+                 "=COLUMN",
+                ]
+            ]);
+            
+            const reader = sheet.openMatrix(nullConsumer);
+
+            assert.deepEqual(
+                extract(reader, 1, 4), [
+                    [1, 4, 4, 4]
+                ]);
+            
+            data.write(0, 0, "=1+1+1+1");
+            sheet.invalidate(0, 0);
+            
+            assert.deepEqual(
+                extract(reader, 1, 4), [
+                    [4, 4, 4, 4]
+                ]);
         });
     });
 });

--- a/packages/core/micro/test/sheetlet.spec.ts
+++ b/packages/core/micro/test/sheetlet.spec.ts
@@ -3,8 +3,9 @@ import { strict as assert } from "assert";
 import "mocha";
 import { createMatrix, matrixProducer } from "../src/matrix";
 import { createSheetlet, Sheetlet } from "../src/sheetlet";
-import { Value } from "../src/types";
 import { makeBenchmark } from "./sheets";
+
+type Value = Primitive | undefined;
 
 describe("Sheetlet", () => {
     function evalCellTest(sheet: IMatrixReader<Value>, row: number, col: number, expected: Primitive) {

--- a/packages/core/micro/test/sheetlet.spec.ts
+++ b/packages/core/micro/test/sheetlet.spec.ts
@@ -8,9 +8,29 @@ import { makeBenchmark } from "./sheets";
 type Value = Primitive | undefined;
 
 const nullConsumer: IMatrixConsumer<unknown> = {
-    rowsChanged() {},
-    colsChanged() {},
-    cellsChanged() {},
+    rowsChanged() { },
+    colsChanged() { },
+    cellsChanged() { },
+}
+
+const testConsumer = (values: Primitive[][]): IMatrixConsumer<Primitive> & { notifications: () => number } => {
+    let notifications = 0;
+    return {
+        notifications: () => notifications,
+        rowsChanged() { },
+        colsChanged() { },
+        cellsChanged(row, col, numRows, numCols, _, producer) {
+            notifications++;
+            const reader = producer.openMatrix(nullConsumer);
+            const endR = row + numRows;
+            const endC = col + numCols;
+            for (let i = row; i < endR; i++) {
+                for (let j = col; j < endC; j++) {
+                    assert.deepEqual(reader.read(i, j), values[i][j]);
+                }
+            }
+        }
+    }
 }
 
 describe("Sheetlet", () => {
@@ -106,76 +126,76 @@ describe("Sheetlet", () => {
             const [data, sheet] = initTest([
                 [1, 2, 3, 4, 5]
             ]);
-            
+
             const reader = sheet.openMatrix(nullConsumer);
 
             assert.deepEqual(
                 extract(reader, 1, 5), [
-                    [1, 2, 3, 4, 5]
-                ]);
-            
+                [1, 2, 3, 4, 5]
+            ]);
+
             data.write(0, 0, "=PRODUCT(B1:E1)");
             data.write(0, 1, "=PRODUCT(C1:E1)");
             data.write(0, 2, "=PRODUCT(D1:E1)");
-            
+
             sheet.invalidate(0, 0);
-            
+
             assert.deepEqual(
                 extract(reader, 1, 5), [
-                    [120, 2, 3, 4, 5]
-                ]);
+                [120, 2, 3, 4, 5]
+            ]);
 
             sheet.invalidate(0, 1);
 
             assert.deepEqual(
                 extract(reader, 1, 5), [
-                    [3600, 60, 3, 4, 5]
-                ]);
+                [3600, 60, 3, 4, 5]
+            ]);
 
             sheet.invalidate(0, 2);
 
             assert.deepEqual(
                 extract(reader, 1, 5), [
-                    [160000, 400, 20, 4, 5]
-                ]);
+                [160000, 400, 20, 4, 5]
+            ]);
 
             data.write(0, 0, 10);
             data.write(0, 4, "=A1+1");
 
             sheet.invalidate(0, 0);
             sheet.invalidate(0, 4);
-            
+
             assert.deepEqual(
                 extract(reader, 1, 5), [
-                    [10, 1936, 44, 4, 11]
-                ]);
-            
+                [10, 1936, 44, 4, 11]
+            ]);
+
         });
 
         it("should handle conditional trickery", () => {
             const [data, sheet] = initTest([
                 [1,
-                 "=IF(A1 = 1, A1 + 1, C1 + 1)",
-                 "=IF(A1 = 1, B1 + 1, D1 + 1)",
-                 "=IF(A1 = 1, C1 + 1, E1 + 1)",
-                 "=IF(A1 = 1, D1 + 1, 10)"
+                    "=IF(A1 = 1, A1 + 1, C1 + 1)",
+                    "=IF(A1 = 1, B1 + 1, D1 + 1)",
+                    "=IF(A1 = 1, C1 + 1, E1 + 1)",
+                    "=IF(A1 = 1, D1 + 1, 10)"
                 ]
             ]);
-            
+
             const reader = sheet.openMatrix(nullConsumer);
 
             assert.deepEqual(
                 extract(reader, 1, 5), [
-                    [1, 2, 3, 4, 5]
-                ]);
-            
+                [1, 2, 3, 4, 5]
+            ]);
+
             data.write(0, 0, 2);
             sheet.invalidate(0, 0);
-            
+
             assert.deepEqual(
                 extract(reader, 1, 5), [
-                    [2, 13, 12, 11, 10]
-                ]);
+                [2, 13, 12, 11, 10]
+            ]);
 
             data.write(0, 1, "=C1 + D1 + E1");
             data.write(0, 4, 11);
@@ -184,59 +204,80 @@ describe("Sheetlet", () => {
 
             assert.deepEqual(
                 extract(reader, 1, 5), [
-                    [2, 36, 13, 12, 11]
-                ]);
+                [2, 36, 13, 12, 11]
+            ]);
         });
 
         it("should handle conditional trickery with aggregations", () => {
             const [data, sheet] = initTest([
                 [1,
-                 "=IF(A1 = 1, 10, SUM(C1:E1)+1)",
-                 "=IF(A1 = 1, 11, SUM(D1:E1)+1)",
-                 "=IF(A1 = 1, 12, SUM(E1:E1)+1)",
-                 "=IF(A1 = 1, 13, 100)",
+                    "=IF(A1 = 1, 10, SUM(C1:E1)+1)",
+                    "=IF(A1 = 1, 11, SUM(D1:E1)+1)",
+                    "=IF(A1 = 1, 12, SUM(E1:E1)+1)",
+                    "=IF(A1 = 1, 13, 100)",
                 ]
             ]);
-            
+
             const reader = sheet.openMatrix(nullConsumer);
 
             assert.deepEqual(
                 extract(reader, 1, 5), [
-                    [1, 10, 11, 12, 13]
-                ]);
-            
+                [1, 10, 11, 12, 13]
+            ]);
+
             data.write(0, 0, 55);
             sheet.invalidate(0, 0);
-            
+
             assert.deepEqual(
                 extract(reader, 1, 5), [
-                    [55, 404, 202, 101, 100]
-                ]);
+                [55, 404, 202, 101, 100]
+            ]);
         });
 
         it("should handle switching", () => {
             const [data, sheet] = initTest([
                 ["=COLUMN",
-                 "=IF(A1 = 1, C1, D1)",
-                 "=IF(A1 = 1, D1, B1)",
-                 "=COLUMN",
+                    "=IF(A1 = 1, C1, D1)",
+                    "=IF(A1 = 1, D1, B1)",
+                    "=COLUMN",
                 ]
             ]);
-            
+
             const reader = sheet.openMatrix(nullConsumer);
 
             assert.deepEqual(
                 extract(reader, 1, 4), [
-                    [1, 4, 4, 4]
-                ]);
-            
+                [1, 4, 4, 4]
+            ]);
+
             data.write(0, 0, "=1+1+1+1");
             sheet.invalidate(0, 0);
-            
+
             assert.deepEqual(
                 extract(reader, 1, 4), [
-                    [4, 4, 4, 4]
-                ]);
+                [4, 4, 4, 4]
+            ]);
         });
+    });
+
+    describe("producer tests", () => {
+        it("simple push", () => {
+            const [data, sheet] = initTest([
+                [1, 2, 3, 4, "=A1 + B1 + C1 + D1"]
+            ]);
+            const consumer = testConsumer([[1, 2, 3, 4, 10]])
+            sheet.openMatrix(consumer);
+            sheet.cellsChanged(0, 0, 1, 5);
+            assert.strictEqual(consumer.notifications(), 1);
+
+            sheet.removeMatrixConsumer(consumer);
+            data.write(0, 0, 20);
+            
+            const consumer2 = testConsumer([[20, 2, 3, 4, 29]])
+            sheet.openMatrix(consumer2);
+            sheet.cellsChanged(0, 0, 1, 1);
+            assert.strictEqual(consumer2.notifications(), 2);
+            
+        })
     });
 });

--- a/packages/core/micro/test/sheets.ts
+++ b/packages/core/micro/test/sheets.ts
@@ -1,5 +1,5 @@
-import { createSheetlet, Sheetlet } from "../src/sheetlet";
-import { createMatrix, matrixProducer } from "../src/matrix";
+import { createSheetletProducer, Sheetlet } from "../src/sheetlet";
+import { createGrid, matrixProducer } from "../src/matrix";
 import { consume } from "../bench/util";
 import { Primitive, IMatrixReader } from "@tiny-calc/nano";
 import { Value } from "../src/types";
@@ -42,7 +42,7 @@ export function makeBenchmark(size: number): { sheet: Sheetlet, setAt: (row: num
     }
 
     const matrix = matrixProducer<Value>(cells);
-    const sheet = createSheetlet(matrix, createMatrix());
+    const sheet = createSheetletProducer(matrix, createGrid());
 
     return {
         sheet,

--- a/packages/core/micro/test/sheets.ts
+++ b/packages/core/micro/test/sheets.ts
@@ -1,47 +1,62 @@
-import { createSheetlet, ISheetlet } from "../src/sheetlet";
-import { c0ToName, Matrix } from "../src/matrix";
+import { createSheetlet, Sheetlet } from "../src/sheetlet";
+import { createMatrix, matrixProducer } from "../src/matrix";
 import { consume } from "../bench/util";
-import { Primitive } from "@tiny-calc/nano";
+import { Primitive, IMatrixReader } from "@tiny-calc/nano";
+import { Value } from "../src/types";
 
-export function makeBenchmark(size: number): { sheet: ISheetlet, setAt: (row: number, col: number, value: Primitive) => void } {
-    const cells = new Array(size * size);
+/** Convert a 0-based column index into an Excel-like column name (e.g., 0 -> 'A') */
+function c0ToName(colIndex: number) {
+    let name = "";
 
-    cells[0] = 0;
+    do {
+        const mod = colIndex % 26;
+        name = `${String.fromCharCode(65 + mod)}${name}`;
+        // tslint:disable-next-line:no-parameter-reassignment
+        colIndex = Math.trunc(colIndex / 26) - 1;
+    } while (colIndex >= 0);
+
+    return name;
+}
+
+export function makeBenchmark(size: number): { sheet: Sheetlet, setAt: (row: number, col: number, value: Primitive) => void } {
+    const cells = new Array(size).fill(undefined).map(() => { return new Array(size) });
+
+    cells[0][0] = 0;
 
     // Cells in column 0 sum all cells above.
     for (let r = 1; r < size; r++) {
-        cells[r * size] = `=SUM(A1:A${r})`;
+        cells[r][0] = `=SUM(A1:A${r})`;
     }
 
     // Cells in row 0 sum all cells to the left.
     for (let c = 1; c < size; c++) {
-        cells[c] = `=SUM(A1:${c0ToName(c - 1)}1)`;
+        cells[0][c] = `=SUM(A1:${c0ToName(c - 1)}1)`;
     }
 
     // Interior cells sum all cells above and/or to the left.
     for (let r = 1; r < size; r++) {
         for (let c = 1; c < size; c++) {
             const col = c0ToName(c);
-            cells[r * size + c] = `=SUM(${col}1:${col}${r}) + SUM(A1:${c0ToName(c - 1)}${r + 1})`;
+            cells[r][c] = `=SUM(${col}1:${col}${r}) + SUM(A1:${c0ToName(c - 1)}${r + 1})`;
         }
     }
 
-    const matrix = new Matrix(size, size, cells);
-    const sheet = createSheetlet(matrix);
+    const matrix = matrixProducer<Value>(cells);
+    const sheet = createSheetlet(matrix, createMatrix());
 
     return {
         sheet,
         setAt: (row: number, col: number, value: Primitive) => {
-            matrix.storeCellText(row, col, value);
+            matrix.write(row, col, value);
             sheet.invalidate(row, col);
         }
     };
 }
 
-export function evalSheet(sheet: ISheetlet, size: number) {
+export function evalSheet(sheet: IMatrixReader<Value>, size: number) {
     for (let r = 0; r < size; r++) {
         for (let c = 0; c < size; c++) {
-            consume(sheet.evaluateCell(r, c));
+            consume(sheet.read(r, c));
         }
     }
     return sheet;

--- a/packages/core/nano/src/compiler.ts
+++ b/packages/core/nano/src/compiler.ts
@@ -19,10 +19,12 @@ import {
 import {
     binOps,
     BinaryOps,
+    createObjectResolver,
+    CoreRuntime,
     Delay,
     Delayed,
     errors,
-    createRuntime,
+    makeTracer,
     unaryOps,
     UnaryOps,
 } from "./core";
@@ -100,7 +102,7 @@ const makeGensym = () => {
     }
 };
 
-function compileAST(gensym: () => number, scope: Record<string, string>, f: ExpressionNode): string {
+function compileAST(gensym: () => number, scope: Record<string, string>, f: ExpressionNode<string>): string {
     switch (f.kind) {
         case NodeKind.Literal:
             return simpleSink.lit(f.value);
@@ -166,8 +168,8 @@ export type Formula = <C>(context: C, root: CalcObj<C>) => [Pending<unknown>[], 
 const parse = createParser(simpleSink, errorHandler);
 
 const formula = (raw: RawFormula): Formula => <O>(origin: O, context: CalcObj<O>) => {
-    const [data, rt, resolver] = createRuntime(context);
-    const result = raw(rt, resolver, errors, origin, context, binOps, unaryOps);
+    const [data, trace] = makeTracer();
+    const result = raw(new CoreRuntime(trace), createObjectResolver(context, trace), errors, origin, context, binOps, unaryOps);
     return [data, result];
 };
 

--- a/packages/core/nano/src/compiler.ts
+++ b/packages/core/nano/src/compiler.ts
@@ -4,6 +4,7 @@ import {
     CalcObj,
     CalcValue,
     Pending,
+    Resolver,
     Runtime,
 } from "./types";
 
@@ -26,7 +27,7 @@ import {
     UnaryOps,
 } from "./core";
 
-import { FormulaNode, NodeKind, parseFormula } from "./ast";
+import { ExpressionNode, NodeKind, parseExpression } from "./ast";
 
 const needsASTCompilation = {};
 const ifIdent = "ef.read(origin,context,\"if\", err.readOnNonObject)";
@@ -56,7 +57,7 @@ const simpleSink = {
             case "FUN":
                 return funIdent;
             default:
-                return fieldAccess ? JSON.stringify(id) : `ef.read(origin,context,${JSON.stringify(id)}, err.readOnNonObject)`;
+                return fieldAccess ? JSON.stringify(id) : `resolver.resolve(origin,${JSON.stringify(id)},err.resolveError)`;
         }
     },
     paren(expr: string) {
@@ -99,7 +100,7 @@ const makeGensym = () => {
     }
 };
 
-function compileAST(gensym: () => number, scope: Record<string, string>, f: FormulaNode): string {
+function compileAST(gensym: () => number, scope: Record<string, string>, f: ExpressionNode): string {
     switch (f.kind) {
         case NodeKind.Literal:
             return simpleSink.lit(f.value);
@@ -158,15 +159,15 @@ function compileAST(gensym: () => number, scope: Record<string, string>, f: Form
     }
 }
 
-type RawFormula = <O>(ef: Runtime<Delay>, err: typeof errors, origin: O, context: CalcObj<O>, binOps: BinaryOps, unaryOps: UnaryOps) => Delayed<CalcValue<O>>;
+type RawFormula = <O>(ef: Runtime<Delay>, resolver: Resolver<O, string, Delay>, err: typeof errors, origin: O, context: CalcObj<O>, binOps: BinaryOps, unaryOps: UnaryOps) => Delayed<CalcValue<O>>;
 export type Formula = <C>(context: C, root: CalcObj<C>) => [Pending<unknown>[], Delayed<CalcValue<C>>];
 
 
 const parse = createParser(simpleSink, errorHandler);
 
 const formula = (raw: RawFormula): Formula => <O>(origin: O, context: CalcObj<O>) => {
-    const [data, rt] = createRuntime();
-    const result = raw(rt, errors, origin, context, binOps, unaryOps);
+    const [data, rt, resolver] = createRuntime(context);
+    const result = raw(rt, resolver, errors, origin, context, binOps, unaryOps);
     return [data, result];
 };
 
@@ -175,16 +176,16 @@ const quickCompile = (text: string) => {
     if (errors) {
         return undefined;
     }
-    return formula(new Function("ef", "err", "origin", "context", "binOps", "unaryOps", `return ${parsed};`) as RawFormula);
+    return formula(new Function("ef", "resolver", "err", "origin", "context", "binOps", "unaryOps", `return ${parsed};`) as RawFormula);
 };
 
 const astCompile = (text: string) => {
-    const [errors, ast] = parseFormula(text);
+    const [errors, ast] = parseExpression(text);
     if (errors) {
         return undefined;
     }
     const parsed = compileAST(makeGensym(), {}, ast);
-    return formula(new Function("ef", "err", "origin", "context", "binOps", "unaryOps", `return ${parsed};`) as RawFormula);
+    return formula(new Function("ef", "resolver", "err", "origin", "context", "binOps", "unaryOps", `return ${parsed};`) as RawFormula);
 };
 
 export const compile = (text: string) => {

--- a/packages/core/nano/src/index.ts
+++ b/packages/core/nano/src/index.ts
@@ -7,7 +7,7 @@ export {
 } from "./ast"
 
 export {
-    createRuntime,
+    CoreRuntime,
     Delay,
     Delayed,
     errors,
@@ -55,6 +55,7 @@ export {
     createParser,
     ExpAlgebra,
     ParserErrorHandler,
+    Parser,
 } from "./parser";
 
 export {

--- a/packages/core/nano/src/index.ts
+++ b/packages/core/nano/src/index.ts
@@ -1,6 +1,9 @@
 export {
-    parseFormula,
-    FormulaNode
+    createAlgebra,
+    ExpressionNode,
+    ident,
+    NodeKind,
+    parseExpression,
 } from "./ast"
 
 export {
@@ -46,6 +49,13 @@ export {
     TypeMap,
     TypeName,
 } from "./types";
+
+export {
+    createBooleanErrorHandler,
+    createParser,
+    ExpAlgebra,
+    ParserErrorHandler,
+} from "./parser";
 
 export {
     produce

--- a/packages/core/nano/src/index.ts
+++ b/packages/core/nano/src/index.ts
@@ -11,8 +11,8 @@ export {
     Delay,
     Delayed,
     errors,
-    isDelayed,
     makeError,
+    makeTracer,
 } from "./core";
 
 export {
@@ -21,6 +21,9 @@ export {
 } from "./compiler";
 
 export {
+    evaluate,
+    evalContext,
+    EvalContext,
     interpret,
     Interpreter
 } from "./interpreter";
@@ -45,6 +48,7 @@ export {
     Primitive,
     ReadableType,
     ReferenceType,
+    Resolver,
     Runtime,
     TypeMap,
     TypeName,

--- a/packages/core/nano/src/index.ts
+++ b/packages/core/nano/src/index.ts
@@ -10,6 +10,7 @@ export {
     CoreRuntime,
     Delay,
     Delayed,
+    isDelayed,
     errors,
     makeError,
     makeTracer,

--- a/packages/core/nano/src/interpreter.ts
+++ b/packages/core/nano/src/interpreter.ts
@@ -20,7 +20,7 @@ import {
     Runtime,
 } from "./types";
 
-interface EvalContext {
+export interface EvalContext {
     readonly errors: Errors;
     readonly binOps: BinaryOps;
     readonly unaryOps: UnaryOps;

--- a/packages/core/nano/src/interpreter.ts
+++ b/packages/core/nano/src/interpreter.ts
@@ -1,4 +1,4 @@
-import { FormulaNode, NodeKind } from "./ast";
+import { ExpressionNode, NodeKind } from "./ast";
 import {
     binOps,
     BinaryOps,
@@ -14,6 +14,7 @@ import {
     CalcObj,
     CalcValue,
     Pending,
+    Resolver,
     Runtime,
 } from "./types";
 
@@ -23,83 +24,83 @@ interface EvalContext {
     readonly unaryOps: UnaryOps;
 }
 
-export function evaluate<O, Delay>(ctx: EvalContext, origin: O, rt: Runtime<Delay>, root: CalcObj<O>, formula: FormulaNode): CalcValue<O> | Delay {
-    switch (formula.kind) {
+export function evaluate<O, Delay>(ctx: EvalContext, origin: O, rt: Runtime<Delay>, resolver: Resolver<O, string, Delay>, expr: ExpressionNode): CalcValue<O> | Delay {
+    switch (expr.kind) {
         case NodeKind.Literal:
-            return formula.value;
-            
+            return expr.value;
+
         case NodeKind.Ident:
-            return rt.read(origin, root, formula.value, ctx.errors.readOnNonObject);
-            
+            return resolver.resolve(origin, expr.value, ctx.errors.resolveError);
+
         case NodeKind.Paren:
-            return evaluate(ctx, origin, rt, root, formula.value);
-            
+            return evaluate(ctx, origin, rt, resolver, expr.value);
+
         case NodeKind.Fun:
             throw "TODO: funs";
-            
+
         case NodeKind.App:
-            const appArgs = formula.children;
+            const appArgs = expr.children;
             if (appArgs.length === 0) {
                 return ctx.errors.functionArity;
             }
-            const head = evaluate(ctx, origin, rt, root, appArgs[0]);
+            const head = evaluate(ctx, origin, rt, resolver, appArgs[0]);
             const evaluatedArgs: (CalcValue<O> | Delay)[] = [];
             for (let i = 1; i < appArgs.length; i += 1) {
-                evaluatedArgs.push(evaluate(ctx, origin, rt, root, appArgs[i]));
+                evaluatedArgs.push(evaluate(ctx, origin, rt, resolver, appArgs[i]));
             }
             return rt.appN(origin, head, evaluatedArgs, ctx.errors.appOnNonFunction);
-            
+
         case NodeKind.Conditional:
-            const condArgs = formula.children;
+            const condArgs = expr.children;
             if (condArgs.length === 0) {
                 return ctx.errors.functionArity;
             }
-            const cond = evaluate(ctx, origin, rt, root, condArgs[0]);
+            const cond = evaluate(ctx, origin, rt, resolver, condArgs[0]);
             if (rt.isDelayed(cond)) {
                 return cond;
             }
             // TODO: coercion
             if (cond) {
-                return condArgs[1] ? evaluate(ctx, origin, rt, root, condArgs[1]) : true;
+                return condArgs[1] ? evaluate(ctx, origin, rt, resolver, condArgs[1]) : true;
             }
-            return condArgs[2] ? evaluate(ctx, origin, rt, root, condArgs[2]) : false;
-            
+            return condArgs[2] ? evaluate(ctx, origin, rt, resolver, condArgs[2]) : false;
+
         case NodeKind.Dot:
-            const obj = evaluate(ctx, origin, rt, root, formula.operand1);
-            if (formula.operand2.kind === NodeKind.Ident) {
-                return rt.read(origin, obj, formula.operand2.value, ctx.errors.readOnNonObject);
+            const obj = evaluate(ctx, origin, rt, resolver, expr.operand1);
+            if (expr.operand2.kind === NodeKind.Ident) {
+                return rt.read(origin, obj, expr.operand2.value, ctx.errors.readOnNonObject);
             }
             return ctx.errors.nonStringField;
-            
+
         case NodeKind.BinaryOp:
             return rt.app2(
                 origin,
-                ctx.binOps[formula.op],
-                evaluate(ctx, origin, rt, root, formula.operand1),
-                evaluate(ctx, origin, rt, root, formula.operand2)
+                ctx.binOps[expr.op],
+                evaluate(ctx, origin, rt, resolver, expr.operand1),
+                evaluate(ctx, origin, rt, resolver, expr.operand2)
             );
-            
+
         case NodeKind.UnaryOp:
             return rt.app1(
                 origin,
-                ctx.unaryOps[formula.op],
-                evaluate(ctx, origin, rt, root, formula.operand1)
+                ctx.unaryOps[expr.op],
+                evaluate(ctx, origin, rt, resolver, expr.operand1)
             );
-            
+
         case NodeKind.Missing:
             throw "TODO: missing";
-            
+
         default:
             // TODO: assert never;
-            throw `Unreachable: ${JSON.stringify(formula)}`;
+            throw `Unreachable: ${JSON.stringify(expr)}`;
     }
 }
 
-export type Interpreter = <O>(origin: O, context: CalcObj<O>, formula: FormulaNode) => [Pending<unknown>[], Delayed<CalcValue<O>>];
+export type Interpreter = <O>(origin: O, root: CalcObj<O>, expr: ExpressionNode) => [Pending<unknown>[], Delayed<CalcValue<O>>];
 
 export const evalContext: EvalContext = { errors, binOps, unaryOps };
 
-export const interpret: Interpreter = (origin, context, formula) => {
-    const [data, rt] = createRuntime();
-    return [data, evaluate(evalContext, origin, rt, context, formula)];
+export const interpret: Interpreter = (origin, root, expr) => {
+    const [data, rt, resolver] = createRuntime(root);
+    return [data, evaluate(evalContext, origin, rt, resolver, expr)];
 }

--- a/packages/core/nano/src/types.ts
+++ b/packages/core/nano/src/types.ts
@@ -154,12 +154,16 @@ export interface TypedBinOp<A> {
  * Evaluation Runtime
  */
 export interface Runtime<Delay> {
-    isDelayed(v: unknown): v is Delay;
+    isDelayed: (v: unknown) => v is Delay;
     read: <C, F>(context: C, receiver: CalcValue<C> | Delay, prop: string, fallback: F) => CalcValue<C> | F | Delay;
     ifS: <T>(cond: boolean | Delay, cont: (cond: boolean) => T | Delay) => T | Delay;
     app1: <A, C>(context: C, op: TypedUnaryOp<A>, expr: CalcValue<C> | Delay) => CalcValue<C> | Delay;
     app2: <A, C>(context: C, op: TypedBinOp<A>, l: CalcValue<C> | Delay, r: CalcValue<C> | Delay) => CalcValue<C> | Delay;
     appN: <C, F>(context: C, fn: CalcValue<C> | Delay, args: (CalcValue<C> | Delay)[], fallback: F) => CalcValue<C> | F | Delay;
+}
+
+export interface Resolver<C, Ref, Delay> {
+    resolve: <F>(context: C, ref: Ref, failure: F) => CalcValue<C> | F | Delay
 }
 
 /**

--- a/packages/core/nano/test/nano.spec.ts
+++ b/packages/core/nano/test/nano.spec.ts
@@ -1,4 +1,4 @@
-import { parseFormula } from "../src/ast";
+import { parseExpression } from "../src/ast";
 import { createDiagnosticErrorHandler, createParser, SyntaxKind, ExpAlgebra } from "../src/parser";
 import { compile } from "../src/compiler";
 import { interpret } from "../src/interpreter";
@@ -190,7 +190,7 @@ describe("nano", () => {
 
     function interpretTest(expression: string, expected: CalcValue<unknown>, serialise: boolean | undefined) {
         it(`Interpret: ${expression}`, () => {
-            const [errors, formula] = parseFormula(expression);
+            const [errors, formula] = parseExpression(expression);
             assert.strictEqual(errors, false);
             const [pending, actual] = interpret(undefined, testContext, formula);
             assert.deepEqual(pending, []);

--- a/packages/test/example/src/async.ts
+++ b/packages/test/example/src/async.ts
@@ -8,8 +8,8 @@ import {
     CalcObj,
     CalcValue,
     interpret,
-    parseFormula,
-    FormulaNode
+    parseExpression,
+    ExpressionNode,
 } from "@tiny-calc/nano";
 
 let cache: Record<string, CalcObj<unknown> | PendingPromise> = {};
@@ -70,17 +70,17 @@ const read = (prop: string) => {
 const delayedCalcValue: CalcObj<unknown> = createObjFromMap(createReadMap(read));
 
 
-const f = parseFormula(`Q978185.labels.en.value + ' was last modified ' + Q978185.modified + '. ' +
+const f = parseExpression(`Q978185.labels.en.value + ' was last modified ' + Q978185.modified + '. ' +
 Q2005.labels.en.value + ' was last modified ' + Q2005.modified
 `)[1];
 
-const g = parseFormula("Q5")[1];
+const g = parseExpression("Q5")[1];
 
 /**
  * Care needs to be taken when using promise loops as they have a
  * tendency to leak memory.
  */
-async function runFormula(f: FormulaNode, attempts: number): Promise<CalcValue<unknown>> {
+async function runFormula(f: ExpressionNode<string>, attempts: number): Promise<CalcValue<unknown>> {
     let [pendings, value] = interpret(undefined as unknown, delayedCalcValue, f);
     while (isDelayed(value)) {
         if (attempts > 0) {

--- a/packages/test/example/src/types.ts
+++ b/packages/test/example/src/types.ts
@@ -1,9 +1,9 @@
 import {
-    parseFormula,
+    parseExpression,
     Pending,
     IConsumer,
     IProducer,
-    FormulaNode,
+    ExpressionNode,
     interpret,
     Primitive,
     TypeMap,
@@ -89,14 +89,14 @@ function createCalcValue(v: Producer) {
 }
 
 export class ListFormula implements FormulaHost {
-    private formulas: FormulaNode[];
+    private formulas: ExpressionNode<string>[];
     constructor(
         private scope: Producer,
         private formulaText: string,
         private withValue: (v: any[]) => void
     ) {
         this.formulas = [];
-        const [errors, formula] = parseFormula(this.formulaText);
+        const [errors, formula] = parseExpression(this.formulaText);
         if (!errors) {
             for (let i = 0; i < 1000000; i += 1) {
                 this.formulas.push(formula);


### PR DESCRIPTION
This maintains the same API with existing consumers of micro, but ideally we want to move away from the `IMatrix` interface.

I'm using a simple tiled grid for a cache. It would good to plumb in something better.

I'm not quite sure I've got the notifications for recalculated formulas right. When cell changes are pushed to the sheetlet we invalidate and recalculate the chain, which is some subset of the formulas in the sheet. The chain is populated by changing the region, or by reading from a cell that has a formula. A formula in a cell that has never been updated or read from will not be calculated at all.

I've probably need to be consistent with the dimensions of the grid we are dealing with. I've currently limited cell references to only parse if they are within Excel bounds.

Other changes include switching to the interpreter, and allow the parser to statically resolve string identifiers (this is how I get cell refs in the AST).

Closes #49.