### PR TITLE
Nano: Updates to Map/Vector/Matrix interfaces

### DIFF
--- a/packages/core/micro/src/binder.ts
+++ b/packages/core/micro/src/binder.ts
@@ -21,10 +21,10 @@ export function initBinder(): Binder {
             }
         },
         getDependents(row: number, col: number) {
-            return grid.read(row, col);
+            return grid.getCell(row, col);
         },
         clearDependents(row: number, col: number) {
-            const s = grid.read(row, col);
+            const s = grid.getCell(row, col);
             if (s) {
                 s.clear();
             }

--- a/packages/core/micro/src/matrix.ts
+++ b/packages/core/micro/src/matrix.ts
@@ -239,7 +239,7 @@ function initGrid<T>(): SparseGrid<T> {
 export function createGrid<T>(): IGrid<T> {
     const cells: SparseGrid<T> = initGrid();
     return {
-        read(row: number, col: number) {
+        getCell(row: number, col: number) {
             return getCell(row, col, cells);
         },
         write(row: number, col: number, value: T) {

--- a/packages/core/micro/src/matrix.ts
+++ b/packages/core/micro/src/matrix.ts
@@ -188,8 +188,8 @@ function colIdxUnshifted(col: number, level: 0 | 1 | 2 | 3): number {
     return ((col >> (level * CONSTS.LOGW)) & CONSTS.MW);
 }
 
-export function forEachCellInColumns<T>(grid: SparseGrid<T>, columnStart: number, numCols: number, cb: (r: number, c: number, value: T) => void): void {
-    const colEnd = columnStart + numCols - 1;
+export function forEachCellInColumns<T>(grid: SparseGrid<T>, columnStart: number, colCount: number, cb: (r: number, c: number, value: T) => void): void {
+    const colEnd = columnStart + colCount - 1;
     for (let r1 = 0; r1 < CONSTS.H; r1++) {
         const cStart1 = colIdxUnshifted(columnStart, 3);
         const cEnd1 = colIdxUnshifted(colEnd, 3);
@@ -263,8 +263,8 @@ export function matrixProducer<T>(data: T[][]): IMatrixProducer<T | undefined> &
         }
     }
     return {
-        numRows: data.length,
-        numCols: data.length > 0 ? data[0].length : 0,
+        rowCount: data.length,
+        colCount: data.length > 0 ? data[0].length : 0,
         ...grid,
         removeMatrixConsumer() { },
         openMatrix() { return this },

--- a/packages/core/micro/src/sheetlet.ts
+++ b/packages/core/micro/src/sheetlet.ts
@@ -250,7 +250,7 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
     reader: IMatrixReader<Value> = {
         numRows: 0,
         numCols: 0,
-        read: () => undefined
+        getCell: () => undefined
     };
     numRows: number = -1;
     numCols: number = -1;
@@ -392,7 +392,7 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
     createDirtier() {
         const { cache, binder } = this;
         function runDirtier(row: number, col: number) {
-            const cell = cache.read(row, col);
+            const cell = cache.getCell(row, col);
             if (cell === undefined || !isFormulaCell(cell)) {
                 const deps = binder.getDependents(row, col);
                 if (deps) {
@@ -436,7 +436,7 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
 
     refresh = (formula: FormulaCell<CellValue>) => {
         const { row, col } = formula;
-        const cell = this.cache.read(row, col);
+        const cell = this.cache.getCell(row, col);
         if (cell === formula) {
             this.cache.clear(row, col);
             return this.readCache(row, col);
@@ -445,9 +445,9 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
     }
 
     readCache = (row: number, col: number) => {
-        let cell = this.cache.read(row, col);
+        let cell = this.cache.getCell(row, col);
         if (cell === undefined) {
-            cell = makeCell(row, col, this.reader!.read(row, col));
+            cell = makeCell(row, col, this.reader!.getCell(row, col));
             if (cell !== undefined) {
                 this.cache.write(row, col, cell);
             }
@@ -471,10 +471,10 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
     }
 
     evaluateCell(row: number, col: number) {
-        return this.read(row, col);
+        return this.getCell(row, col);
     }
 
-    read(row: number, col: number): Value {
+    getCell(row: number, col: number): Value {
         let cell = this.readCache(row, col);
         if (cell === undefined) {
             return undefined;
@@ -608,7 +608,7 @@ function wrapIMatrix(matrix: IMatrix): IMatrixProducer<Value> {
     const producer = {
         get numRows() { return matrix.numRows },
         get numCols() { return matrix.numCols },
-        read(row: number, col: number) {
+        getCell(row: number, col: number) {
             const raw = matrix.loadCellText(row, col);
             return typeof raw === "object"
                 ? undefined

--- a/packages/core/micro/src/sheetlet.ts
+++ b/packages/core/micro/src/sheetlet.ts
@@ -353,15 +353,15 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
                 }
             }
         }
-        this.consumer0!.cellsChanged(row, col, numRows, numCols, undefined, this);
-        this.consumers.forEach(consumer => consumer.cellsChanged(row, col, numRows, numCols, undefined, this));
+        this.consumer0!.cellsChanged(row, col, numRows, numCols, this);
+        this.consumers.forEach(consumer => consumer.cellsChanged(row, col, numRows, numCols, this));
 
         for (let i = 0; i < this.chain.length; i++) {
             const cell = this.chain[i];
             if ((cell.flags & CalcFlags.PendingNotification)) {
                 cell.flags &= ~CalcFlags.PendingNotification;
-                this.consumer0!.cellsChanged(cell.row, cell.col, 1, 1, undefined, this);
-                this.consumers.forEach(consumer => consumer.cellsChanged(cell.row, cell.col, 1, 1, undefined, this));
+                this.consumer0!.cellsChanged(cell.row, cell.col, 1, 1, this);
+                this.consumers.forEach(consumer => consumer.cellsChanged(cell.row, cell.col, 1, 1, this));
             }
         }
     }

--- a/packages/core/micro/src/sheetlet.ts
+++ b/packages/core/micro/src/sheetlet.ts
@@ -248,12 +248,12 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
 
     chain: FormulaCell<CellValue>[] = [];
     reader: IMatrixReader<Value> = {
-        numRows: 0,
-        numCols: 0,
+        rowCount: 0,
+        colCount: 0,
         getCell: () => undefined
     };
-    numRows: number = -1;
-    numCols: number = -1;
+    rowCount: number = -1;
+    colCount: number = -1;
     consumer0: IMatrixConsumer<Value> | undefined;
     consumers: IMatrixConsumer<Value>[] = [];
 
@@ -282,13 +282,13 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
 
     connect(producer: IMatrixProducer<Value>) {
         this.reader = producer.openMatrix(this);
-        this.numRows = this.reader.numRows;
-        this.numCols = this.reader.numCols;
+        this.rowCount = this.reader.rowCount;
+        this.colCount = this.reader.colCount;
         return this;
     }
 
     rowsChanged(row: number, numRemoved: number, numInserted: number) {
-        this.numRows = this.reader.numRows;
+        this.rowCount = this.reader.rowCount;
         if (this.consumer0) {
             this.consumer0.rowsChanged(row, numRemoved, numInserted, this);
             this.consumers.forEach(consumer => consumer.rowsChanged(row, numRemoved, numInserted, this));
@@ -296,7 +296,7 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
     }
 
     colsChanged(col: number, numRemoved: number, numInserted: number) {
-        this.numCols = this.reader.numCols;
+        this.colCount = this.reader.colCount;
         if (this.consumer0) {
             this.consumer0.colsChanged(col, numRemoved, numInserted, this);
             this.consumers.forEach(consumer => consumer.colsChanged(col, numRemoved, numInserted, this));
@@ -321,9 +321,9 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
         }
     }
 
-    cellsChanged(row: number, col: number, numRows: number, numCols: number) {
-        const endR = row + numRows;
-        const endC = col + numCols;
+    cellsChanged(row: number, col: number, rowCount: number, colCount: number) {
+        const endR = row + rowCount;
+        const endC = col + colCount;
         const dirty = this.createDirtier();
         for (let i = row; i < endR; i++) {
             for (let j = col; j < endC; j++) {
@@ -353,8 +353,8 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
                 }
             }
         }
-        this.consumer0!.cellsChanged(row, col, numRows, numCols, this);
-        this.consumers.forEach(consumer => consumer.cellsChanged(row, col, numRows, numCols, this));
+        this.consumer0!.cellsChanged(row, col, rowCount, colCount, this);
+        this.consumers.forEach(consumer => consumer.cellsChanged(row, col, rowCount, colCount, this));
 
         for (let i = 0; i < this.chain.length; i++) {
             const cell = this.chain[i];
@@ -606,8 +606,8 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
 
 function wrapIMatrix(matrix: IMatrix): IMatrixProducer<Value> {
     const producer = {
-        get numRows() { return matrix.numRows },
-        get numCols() { return matrix.numCols },
+        get rowCount() { return matrix.rowCount },
+        get colCount() { return matrix.colCount },
         getCell(row: number, col: number) {
             const raw = matrix.loadCellText(row, col);
             return typeof raw === "object"

--- a/packages/core/micro/src/types.ts
+++ b/packages/core/micro/src/types.ts
@@ -110,7 +110,7 @@ export interface Binder {
  * IGrid denotes a 2D cache for values of type `T`.
  */
 export interface IGrid<T> {
-    read(row: number, col: number): T | undefined;
+    getCell(row: number, col: number): T | undefined;
     write(row: number, col: number, value: T): void;
     // Undefined means invalid row or col.
     readOrWrite(row: number, col: number, value: () => T): T | undefined;

--- a/packages/core/micro/src/types.ts
+++ b/packages/core/micro/src/types.ts
@@ -121,8 +121,8 @@ export interface IGrid<T> {
  * Legacy Interface
  */
 export interface IMatrix {
-   readonly numRows: number;
-   readonly numCols: number;
+   readonly rowCount: number;
+   readonly colCount: number;
    loadCellText: (row: number, col: number) => Primitive | undefined;
    loadCellData: (row: number, col: number) => object | undefined;
    storeCellData: (row: number, col: number, value: object | undefined) => void;

--- a/packages/core/micro/test/sheetlet.spec.ts
+++ b/packages/core/micro/test/sheetlet.spec.ts
@@ -17,7 +17,7 @@ const nullConsumer: IMatrixConsumer<unknown> = {
 describe("Sheetlet", () => {
     function evalCellTest(sheet: IMatrixReader<Value>, row: number, col: number, expected: Primitive) {
         it(`[${row},${col}] -> ${JSON.stringify(expected)}`, () => {
-            assert.deepEqual(sheet.read(row, col), expected);
+            assert.deepEqual(sheet.getCell(row, col), expected);
         });
     }
 
@@ -33,7 +33,7 @@ describe("Sheetlet", () => {
             let row: (Primitive | undefined)[] = [];
             matrix.push(row);
             for (let c = 0; c < numCols; c++) {
-                row.push(sheet.read(r, c));
+                row.push(sheet.getCell(r, c));
             }
         }
         return matrix;

--- a/packages/core/micro/test/sheetlet.spec.ts
+++ b/packages/core/micro/test/sheetlet.spec.ts
@@ -27,12 +27,12 @@ describe("Sheetlet", () => {
         });
     }
 
-    function extract(sheet: IMatrixReader<Value>, numRows: number, numCols: number) {
+    function extract(sheet: IMatrixReader<Value>, rowCount: number, colCount: number) {
         let matrix = [];
-        for (let r = 0; r < numRows; r++) {
+        for (let r = 0; r < rowCount; r++) {
             let row: (Primitive | undefined)[] = [];
             matrix.push(row);
-            for (let c = 0; c < numCols; c++) {
+            for (let c = 0; c < colCount; c++) {
                 row.push(sheet.getCell(r, c));
             }
         }
@@ -318,8 +318,8 @@ describe("Sheetlet", () => {
                     "producer": "sheet",
                     "row": 0,
                     "col": 0,
-                    "numRows": 1,
-                    "numCols": 5,
+                    "rowCount": 1,
+                    "colCount": 5,
                 }
             ]);
 
@@ -334,15 +334,15 @@ describe("Sheetlet", () => {
                     "producer": "sheet",
                     "row": 0,
                     "col": 0,
-                    "numRows": 1,
-                    "numCols": 1,
+                    "rowCount": 1,
+                    "colCount": 1,
                 },
                 {
                     "producer": "sheet",
                     "row": 0,
                     "col": 4,
-                    "numRows": 1,
-                    "numCols": 1,
+                    "rowCount": 1,
+                    "colCount": 1,
                 }
             ]);
         })

--- a/packages/core/micro/test/sheetlet.spec.ts
+++ b/packages/core/micro/test/sheetlet.spec.ts
@@ -316,8 +316,8 @@ describe("Sheetlet", () => {
             consumer.expect([
                 {
                     "producer": "sheet",
-                    "row": 0,
-                    "col": 0,
+                    "rowStart": 0,
+                    "colStart": 0,
                     "rowCount": 1,
                     "colCount": 5,
                 }
@@ -332,19 +332,19 @@ describe("Sheetlet", () => {
             consumer2.expect([
                 {
                     "producer": "sheet",
-                    "row": 0,
-                    "col": 0,
+                    "rowStart": 0,
+                    "colStart": 0,
                     "rowCount": 1,
                     "colCount": 1,
                 },
                 {
                     "producer": "sheet",
-                    "row": 0,
-                    "col": 4,
+                    "rowStart": 0,
+                    "colStart": 4,
                     "rowCount": 1,
                     "colCount": 1,
                 }
             ]);
-        })
+        });
     });
 });

--- a/packages/core/micro/test/sheets.ts
+++ b/packages/core/micro/test/sheets.ts
@@ -56,7 +56,7 @@ export function makeBenchmark(size: number): { sheet: Sheetlet, setAt: (row: num
 export function evalSheet(sheet: IMatrixReader<Value>, size: number) {
     for (let r = 0; r < size; r++) {
         for (let c = 0; c < size; c++) {
-            consume(sheet.read(r, c));
+            consume(sheet.getCell(r, c));
         }
     }
     return sheet;

--- a/packages/core/nano/src/produce.ts
+++ b/packages/core/nano/src/produce.ts
@@ -10,13 +10,14 @@ const unitFn = () => {};
 const props = {
     open: { value: function() { return this; }},
     removeConsumer: { value: unitFn },
-    read: { value: function(key: PropertyKey) { return (this as any)[key]; }},
+    get: { value: function(key: PropertyKey) { return (this as any)[key]; }},
 }
 
 const vectorProps = {
     ...props,
-    openVector: { value: function() { return this; }},
-    removeVectorConsumer: { value: unitFn },
+    openVector: props.open,
+    removeVectorConsumer: props.removeConsumer,
+    getItem: props.get,
 }
 
 export function produce<T>(subject: ArrayLike<T>): IProducer<ArrayLike<T>> & IVectorProducer<T>;

--- a/packages/core/nano/src/types.ts
+++ b/packages/core/nano/src/types.ts
@@ -249,12 +249,12 @@ export interface IMatrixConsumer<T> {
      * matrix has the new cell values already in an array, it may optionally pass these to consumers
      * as an optimization.
      */
-    cellsChanged(row: number, col: number, numRows: number, numCols: number, producer: IMatrixProducer<T>): void;
+    cellsChanged(row: number, col: number, rowCount: number, colCount: number, producer: IMatrixProducer<T>): void;
 }
 
 export interface IMatrixReader<T> {
-    readonly numRows: number;
-    readonly numCols: number;
+    readonly rowCount: number;
+    readonly colCount: number;
     getCell(row: number, col: number): T;
 }
 

--- a/packages/core/nano/src/types.ts
+++ b/packages/core/nano/src/types.ts
@@ -25,7 +25,7 @@ export type Primitive = boolean | number | string;
 
 export interface CalcObj<C> {
     /** 
-     * An object's type map descibes the behaviours the object
+     * An object's type map describes the behaviours the object
      * supports. Type maps are immutable.
      *
      * The purpose of the `this` type is to allow authors to implement
@@ -190,7 +190,7 @@ export interface IReader<T> {
      * Return the value associated with `property`.
      * @param property - The property of the Producer to read.
      */
-    read<K extends keyof T>(property: K): T[K] | Pending<T[K]>;
+    get<K extends keyof T>(property: K): T[K] | Pending<T[K]>;
 }
 
 /**
@@ -223,7 +223,7 @@ export interface IVectorConsumer<T> {
 
 export interface IVectorReader<T> {
     readonly length: number;
-    read(index: number): T;
+    getItem(index: number): T;
 }
 
 /** Provides more efficient access to 1D data for vector-aware consumers. */
@@ -255,7 +255,7 @@ export interface IMatrixConsumer<T> {
 export interface IMatrixReader<T> {
     readonly numRows: number;
     readonly numCols: number;
-    read(row: number, col: number): T;
+    getCell(row: number, col: number): T;
 }
 
 /** Provides more efficient access to 2D data for matrix-aware consumers. */

--- a/packages/core/nano/src/types.ts
+++ b/packages/core/nano/src/types.ts
@@ -182,7 +182,7 @@ export interface IConsumer<T> {
     /**
      * Invoked whenever the data this object is bound to is changed.
      */
-    valueChanged<U extends T, K extends keyof U>(property: K, value: U[K], producer: IProducer<U>): void;
+    valueChanged<U extends T, K extends keyof U>(property: K, producer: IProducer<U>): void;
 }
 
 export interface IReader<T> {
@@ -218,7 +218,7 @@ export interface IProducer<T> {
 
 export interface IVectorConsumer<T> {
     /** Notification that a range of items have been inserted, removed, and/or replaced in the given vector. */
-    itemsChanged(index: number, numRemoved: number, itemsInserted: ReadonlyArray<T>, producer: IVectorProducer<T>): void;
+    itemsChanged(index: number, numRemoved: number, numInserted: number, producer: IVectorProducer<T>): void;
 }
 
 export interface IVectorReader<T> {
@@ -249,7 +249,7 @@ export interface IMatrixConsumer<T> {
      * matrix has the new cell values already in an array, it may optionally pass these to consumers
      * as an optimization.
      */
-    cellsChanged(row: number, col: number, numRows: number, numCols: number, values: ReadonlyArray<T> | undefined, producer: IMatrixProducer<T>): void;
+    cellsChanged(row: number, col: number, numRows: number, numCols: number, producer: IMatrixProducer<T>): void;
 }
 
 export interface IMatrixReader<T> {

--- a/packages/core/nano/src/types.ts
+++ b/packages/core/nano/src/types.ts
@@ -218,7 +218,7 @@ export interface IProducer<T> {
 
 export interface IVectorConsumer<T> {
     /** Notification that a range of items have been inserted, removed, and/or replaced in the given vector. */
-    itemsChanged(index: number, numRemoved: number, numInserted: number, producer: IVectorProducer<T>): void;
+    itemsChanged(start: number, removedCount: number, insertedCount: number, producer: IVectorProducer<T>): void;
 }
 
 export interface IVectorReader<T> {
@@ -239,17 +239,17 @@ export interface IVectorProducer<T> {
 
 export interface IMatrixConsumer<T> {
     /** Notification that rows have been inserted, removed, and/or replaced in the given matrix. */
-    rowsChanged(row: number, numRemoved: number, numInserted: number, producer: IMatrixProducer<T>): void;
+    rowsChanged(rowStart: number, removedCount: number, insertedCount: number, producer: IMatrixProducer<T>): void;
 
     /** Notification that cols have been inserted, removed, and/or replaced in the given matrix. */
-    colsChanged(col: number, numRemoved: number, numInserted: number, producer: IMatrixProducer<T>): void;
+    colsChanged(colStart: number, removedCount: number, insertedCount: number, producer: IMatrixProducer<T>): void;
 
     /**
      * Notification that a range of cells have been replaced in the given matrix.  If the source
      * matrix has the new cell values already in an array, it may optionally pass these to consumers
      * as an optimization.
      */
-    cellsChanged(row: number, col: number, rowCount: number, colCount: number, producer: IMatrixProducer<T>): void;
+    cellsChanged(rowStart: number, colStart: number, rowCount: number, colCount: number, producer: IMatrixProducer<T>): void;
 }
 
 export interface IMatrixReader<T> {

--- a/packages/core/nano/test/produce.spec.ts
+++ b/packages/core/nano/test/produce.spec.ts
@@ -10,8 +10,8 @@ describe("produce()", () => {
             const p = produce({ a: 1 });
             assert.equal("openVector" in p, false);
             const r = p.open(nullConsumer);
-            assert.equal(r.read("a"), 1);
-            assert.equal(r.read("b" as any), undefined);
+            assert.equal(r.get("a"), 1);
+            assert.equal(r.get("b" as any), undefined);
         });
 
         it("handles cycles", () => {
@@ -21,24 +21,24 @@ describe("produce()", () => {
 
             const p = produce(root);
             const r = p.open(nullConsumer);
-            const childProducer = r.read("child") as unknown as IProducer<any>;
+            const childProducer = r.get("child") as unknown as IProducer<any>;
             const childReader = childProducer.open(nullConsumer);
-            assert.equal(childReader.read("parent"), p);
+            assert.equal(childReader.get("parent"), p);
         });
-    })
+    });
 
     describe("array", () => {
         it("supports open() and openVector()", () => {
             const p = produce([0]);
             const r = p.open(nullConsumer);
-            assert.equal(r.read("length"), 1);
-            assert.equal(r.read("0" as any), 0);
-            assert.equal(r.read("1" as any), undefined);
+            assert.equal(r.get("length"), 1);
+            assert.equal(r.get("0" as any), 0);
+            assert.equal(r.get("1" as any), undefined);
 
             const v = p.openVector(nullConsumer);
             assert.equal(v.length, 1);
-            assert.equal(v.read(0), 0);
-            assert.equal(v.read(1), undefined);
+            assert.equal(v.getItem(0), 0);
+            assert.equal(v.getItem(1), undefined);
         });
 
         it("handles cycles", () => {
@@ -48,9 +48,9 @@ describe("produce()", () => {
 
             const p = produce(root);
             const r = p.openVector(nullConsumer);
-            const childProducer = r.read(0);
+            const childProducer = r.getItem(0);
             const childReader = childProducer.open(nullConsumer);
-            assert.equal(childReader.read(0), p);
+            assert.equal(childReader.getItem(0), p);
         });
     });
 });

--- a/packages/core/nano/test/util/loggingConsumer.ts
+++ b/packages/core/nano/test/util/loggingConsumer.ts
@@ -8,14 +8,14 @@ export class LoggingConsumer<T> implements IConsumer<T>, IVectorConsumer<T>, IMa
     private getProducerId(producer: any) { return producer.id || "Error: Missing call to LoggingConsumer.setProducerId(..)"; }
 
     // #region IConsumer<T>
-    public valueChanged<U extends T, K extends keyof U>(property: K, value: U[K], producer: IProducer<U>): void {
-        this.log.push({ property, value, producer: this.getProducerId(producer) });
+    public valueChanged<U extends T, K extends keyof U>(property: K, producer: IProducer<U>): void {
+        this.log.push({ property, producer: this.getProducerId(producer) });
     }
     // #endregion IConsumer<T>
     
     // #region IVectorConsumer<T>
-    public itemsChanged(index: number, numRemoved: number, itemsInserted: ReadonlyArray<T>, producer: IVectorProducer<T>): void {
-        this.log.push({ index, numRemoved, itemsInserted, producer: this.getProducerId(producer) });
+    public itemsChanged(index: number, numRemoved: number, numInserted: number, producer: IVectorProducer<T>): void {
+        this.log.push({ index, numRemoved, numInserted, producer: this.getProducerId(producer) });
     }
     // #endregion IVectorConsumer<T>
     
@@ -28,8 +28,8 @@ export class LoggingConsumer<T> implements IConsumer<T>, IVectorConsumer<T>, IMa
         this.log.push({ col, numRemoved, numInserted, producer: this.getProducerId(producer) });
     }
     
-    public cellsChanged(row: number, col: number, numRows: number, numCols: number, values: ReadonlyArray<T>, producer: IMatrixProducer<T>): void {
-        this.log.push({ row, col, numRows, numCols, values, producer: this.getProducerId(producer) });
+    public cellsChanged(row: number, col: number, numRows: number, numCols: number, producer: IMatrixProducer<T>): void {
+        this.log.push({ row, col, numRows, numCols, producer: this.getProducerId(producer) });
     }
     // #endregion IMatrixConsumer<T>
 

--- a/packages/core/nano/test/util/loggingConsumer.ts
+++ b/packages/core/nano/test/util/loggingConsumer.ts
@@ -14,22 +14,22 @@ export class LoggingConsumer<T> implements IConsumer<T>, IVectorConsumer<T>, IMa
     // #endregion IConsumer<T>
     
     // #region IVectorConsumer<T>
-    public itemsChanged(index: number, numRemoved: number, numInserted: number, producer: IVectorProducer<T>): void {
-        this.log.push({ index, numRemoved, numInserted, producer: this.getProducerId(producer) });
+    public itemsChanged(start: number, removedCount: number, insertedCount: number, producer: IVectorProducer<T>): void {
+        this.log.push({ start, removedCount, insertedCount, producer: this.getProducerId(producer) });
     }
     // #endregion IVectorConsumer<T>
     
     // #region IMatrixConsumer<T>
-    public rowsChanged(row: number, numRemoved: number, numInserted: number, producer: IMatrixProducer<T>): void {
-        this.log.push({ row, numRemoved, numInserted, producer: this.getProducerId(producer) });
+    public rowsChanged(rowStart: number, removedCount: number, insertedCount: number, producer: IMatrixProducer<T>): void {
+        this.log.push({ rowStart, removedCount, insertedCount, producer: this.getProducerId(producer) });
     }
     
-    public colsChanged(col: number, numRemoved: number, numInserted: number, producer: IMatrixProducer<T>): void {
-        this.log.push({ col, numRemoved, numInserted, producer: this.getProducerId(producer) });
+    public colsChanged(colStart: number, removedCount: number, insertedCount: number, producer: IMatrixProducer<T>): void {
+        this.log.push({ colStart, removedCount, insertedCount, producer: this.getProducerId(producer) });
     }
     
-    public cellsChanged(row: number, col: number, rowCount: number, colCount: number, producer: IMatrixProducer<T>): void {
-        this.log.push({ row, col, rowCount, colCount, producer: this.getProducerId(producer) });
+    public cellsChanged(rowStart: number, colStart: number, rowCount: number, colCount: number, producer: IMatrixProducer<T>): void {
+        this.log.push({ rowStart, colStart, rowCount, colCount, producer: this.getProducerId(producer) });
     }
     // #endregion IMatrixConsumer<T>
 

--- a/packages/core/nano/test/util/loggingConsumer.ts
+++ b/packages/core/nano/test/util/loggingConsumer.ts
@@ -28,8 +28,8 @@ export class LoggingConsumer<T> implements IConsumer<T>, IVectorConsumer<T>, IMa
         this.log.push({ col, numRemoved, numInserted, producer: this.getProducerId(producer) });
     }
     
-    public cellsChanged(row: number, col: number, numRows: number, numCols: number, producer: IMatrixProducer<T>): void {
-        this.log.push({ row, col, numRows, numCols, producer: this.getProducerId(producer) });
+    public cellsChanged(row: number, col: number, rowCount: number, colCount: number, producer: IMatrixProducer<T>): void {
+        this.log.push({ row, col, rowCount, colCount, producer: this.getProducerId(producer) });
     }
     // #endregion IMatrixConsumer<T>
 

--- a/packages/test/example/src/types.ts
+++ b/packages/test/example/src/types.ts
@@ -26,7 +26,7 @@ export class Context implements Producer {
     removeConsumer() { }
 
     open() {
-        return { read: (key: string) => this.fields[key] };
+        return { get: (key: string) => this.fields[key] };
     }
 }
 
@@ -39,7 +39,7 @@ export class TimeProducer implements Producer {
 
     open() {
         const time = Date.now();
-        const reader = { read: () => time };
+        const reader = { get: () => time };
         return reader;
     }
 }
@@ -71,7 +71,7 @@ function createCalcValue(v: Producer) {
             if (cache[message] !== undefined) {
                 return cache[message];
             }
-            const value = v.open(consumer).read(message);
+            const value = v.open(consumer).get(message);
             switch (typeof value) {
                 case "string":
                 case "number":
@@ -129,7 +129,7 @@ export class MathProducer implements Producer {
 
     open() {
         return {
-            read: (property: string) => {
+            get: (property: string) => {
                 switch (property) {
                     case "Max": return MathProducer.max;
                     case "Min": return MathProducer.min;


### PR DESCRIPTION
## Remove 'values' from change notification interfaces
The original thinking behind including an array of changed 'values' was that we would just pass these through from the op performing the insert/remove/set (i.e., it would be convenient & zero-alloc.)

In practice, I'm not finding it useful as we scale up and recalculation is increasingly done in batches / lazily as the consumer pulls.

It's also becoming increasingly rare that we happen to have a 'values' array handy.  It's usually convenient to set vector items / matrix cells point-wise (i.e., using setCell vs. setCells) vs. creating an array to set multiple values simulateously.

Also, as we look at scaling up, it's likely that remote ops will no longer carry the values.

## Rename IReader.read() -> IReader.get*()
Two changes:
* Renamed 'read()' -> 'get()' to align with Map
* Added 'Item' and 'Cell' suffixes so that IReader/IVectorReader/IMatrixReader can all be implemented by the same object.

## Use count/start suffixes when specifying intervals / 2D regions
Minor Intellisense improvement (typing .row will show '.rowCount', '.rowStart', etc.)