### PR TITLE
Nano: Readers provide reference to their underlying producer

### DIFF
--- a/packages/core/micro/src/matrix.ts
+++ b/packages/core/micro/src/matrix.ts
@@ -263,16 +263,12 @@ export function matrixProducer<T>(data: T[][]): IMatrixProducer<T | undefined> &
         }
     }
     
-    const producer = {
+    return {
         rowCount: data.length,
         colCount: data.length > 0 ? data[0].length : 0,
         ...grid,
         closeMatrix() { },
         openMatrix() { return this },
-        matrixProducer: undefined as any as IMatrixProducer<T | undefined>
+        get matrixProducer(): IMatrixProducer<T | undefined> { return this; }
     }
-
-    producer.matrixProducer = producer;
-
-    return producer;
 }

--- a/packages/core/micro/src/matrix.ts
+++ b/packages/core/micro/src/matrix.ts
@@ -266,7 +266,7 @@ export function matrixProducer<T>(data: T[][]): IMatrixProducer<T | undefined> &
         rowCount: data.length,
         colCount: data.length > 0 ? data[0].length : 0,
         ...grid,
-        removeMatrixConsumer() { },
+        closeMatrix() { },
         openMatrix() { return this },
     }
 }

--- a/packages/core/micro/src/matrix.ts
+++ b/packages/core/micro/src/matrix.ts
@@ -262,11 +262,17 @@ export function matrixProducer<T>(data: T[][]): IMatrixProducer<T | undefined> &
             grid.write(i, j, row[j]);
         }
     }
-    return {
+    
+    const producer = {
         rowCount: data.length,
         colCount: data.length > 0 ? data[0].length : 0,
         ...grid,
         closeMatrix() { },
         openMatrix() { return this },
+        matrixProducer: undefined as any as IMatrixProducer<T | undefined>
     }
+
+    producer.matrixProducer = producer;
+
+    return producer;
 }

--- a/packages/core/micro/src/sheetlet.ts
+++ b/packages/core/micro/src/sheetlet.ts
@@ -250,7 +250,8 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
     reader: IMatrixReader<Value> = {
         rowCount: 0,
         colCount: 0,
-        getCell: () => undefined
+        getCell: () => undefined,
+        matrixProducer: undefined as any,
     };
     rowCount: number = -1;
     colCount: number = -1;
@@ -388,6 +389,8 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
             }
         }
     }
+
+    get matrixProducer() { return this; }
 
     createDirtier() {
         const { cache, binder } = this;
@@ -616,7 +619,11 @@ function wrapIMatrix(matrix: IMatrix): IMatrixProducer<Value> {
         },
         openMatrix() { return producer },
         closeMatrix() { },
+        matrixProducer: undefined as any as IMatrixProducer<Value>,
     }
+
+    producer.matrixProducer = producer;
+
     return producer;
 }
 

--- a/packages/core/micro/src/sheetlet.ts
+++ b/packages/core/micro/src/sheetlet.ts
@@ -377,7 +377,7 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
         return this;
     }
 
-    removeMatrixConsumer(consumer: IMatrixConsumer<Value>) {
+    closeMatrix(consumer: IMatrixConsumer<Value>) {
         if (consumer === this.consumer0) {
             this.consumer0 = this.consumers.pop();
             return;
@@ -615,7 +615,7 @@ function wrapIMatrix(matrix: IMatrix): IMatrixProducer<Value> {
                 : raw;
         },
         openMatrix() { return producer },
-        removeMatrixConsumer() { },
+        closeMatrix() { },
     }
     return producer;
 }

--- a/packages/core/micro/src/sheetlet.ts
+++ b/packages/core/micro/src/sheetlet.ts
@@ -607,8 +607,8 @@ export class Sheetlet implements IMatrixConsumer<Value>, IMatrixProducer<Value>,
     }
 }
 
-function wrapIMatrix(matrix: IMatrix): IMatrixProducer<Value> {
-    const producer = {
+function wrapIMatrix(matrix: IMatrix): IMatrixProducer<Value> & IMatrixReader<Value> {
+    return {
         get rowCount() { return matrix.rowCount },
         get colCount() { return matrix.colCount },
         getCell(row: number, col: number) {
@@ -617,14 +617,10 @@ function wrapIMatrix(matrix: IMatrix): IMatrixProducer<Value> {
                 ? undefined
                 : raw;
         },
-        openMatrix() { return producer },
+        openMatrix() { return this },
         closeMatrix() { },
-        matrixProducer: undefined as any as IMatrixProducer<Value>,
-    }
-
-    producer.matrixProducer = producer;
-
-    return producer;
+        get matrixProducer() { return this; }
+    };
 }
 
 export const createSheetlet = (matrix: IMatrix) => new Sheetlet(createGrid()).connect(wrapIMatrix(matrix));

--- a/packages/core/micro/test/sheetlet.spec.ts
+++ b/packages/core/micro/test/sheetlet.spec.ts
@@ -323,7 +323,7 @@ describe("Sheetlet", () => {
                 }
             ]);
 
-            sheet.removeMatrixConsumer(consumer);
+            sheet.closeMatrix(consumer);
             data.write(0, 0, 20);
             
             const consumer2 = new LoggingConsumer();

--- a/packages/core/nano/src/produce.ts
+++ b/packages/core/nano/src/produce.ts
@@ -11,13 +11,15 @@ const props = {
     open: { value: function() { return this; }},
     close: { value: unitFn },
     get: { value: function(key: PropertyKey) { return (this as any)[key]; }},
+    producer: { get: function() { return this; }},
 }
 
 const vectorProps = {
     ...props,
     openVector: props.open,
-    removeVectorConsumer: props.close,
+    closeVector: props.close,
     getItem: props.get,
+    vectorProducer: props.producer,
 }
 
 export function produce<T>(subject: ArrayLike<T>): IProducer<ArrayLike<T>> & IVectorProducer<T>;

--- a/packages/core/nano/src/produce.ts
+++ b/packages/core/nano/src/produce.ts
@@ -9,21 +9,21 @@ const unitFn = () => {};
 
 const props = {
     open: { value: function() { return this; }},
-    removeConsumer: { value: unitFn },
+    close: { value: unitFn },
     get: { value: function(key: PropertyKey) { return (this as any)[key]; }},
 }
 
 const vectorProps = {
     ...props,
     openVector: props.open,
-    removeVectorConsumer: props.removeConsumer,
+    removeVectorConsumer: props.close,
     getItem: props.get,
 }
 
 export function produce<T>(subject: ArrayLike<T>): IProducer<ArrayLike<T>> & IVectorProducer<T>;
 export function produce<T extends Readonly<object>>(subject: T): IProducer<T>;
 export function produce<T extends Readonly<object>>(subject: T): IProducer<T> {
-    if ((subject as any).removeConsumer === unitFn) {
+    if ((subject as any).close === unitFn) {
         return subject as any;
     }
 

--- a/packages/core/nano/src/types.ts
+++ b/packages/core/nano/src/types.ts
@@ -202,18 +202,19 @@ export interface IReader<T> {
  */
 export interface IProducer<T> {
     /**
-     * Unsubscribes a consumer from this producer.
-     * @param consumer - The consumer to unregister from the Producer.
-     */
-    removeConsumer(consumer: IConsumer<T>): void;
-
-    /**
-     * Returns a reader for this producer's values and implicitly subscribes the given
-     * consumer to change notifications from this producer (if it isn't already).
+     * Acquire a reader for this producer's values and implicitly subscribe the consumer
+     * to value change notifications.
      * 
-     * @param consumer - The object to be notified of value changes.
+     * @param consumer - The consumer to be notified of value changes.
      */
     open(consumer: IConsumer<T>): IReader<T>;
+
+    /**
+     * Unsubscribe the consumer from this producer's change notifications.
+     * 
+     * @param consumer - The consumer to unregister from the producer.
+     */
+    close(consumer: IConsumer<T>): void;
 }
 
 export interface IVectorConsumer<T> {
@@ -229,12 +230,19 @@ export interface IVectorReader<T> {
 /** Provides more efficient access to 1D data for vector-aware consumers. */
 export interface IVectorProducer<T> {
     /**
-     * Unsubscribes a consumer from this producer.
-     * @param consumer - The consumer to unregister from the Producer.
+     * Acquire a reader for this vector's values and implicitly subscribe the consumer
+     * to value change notifications.
+     * 
+     * @param consumer - The consumer to be notified of vector changes.
      */
-    removeVectorConsumer(consumer: IVectorConsumer<T>): void;
-
     openVector(consumer: IVectorConsumer<T>): IVectorReader<T>;
+
+    /**
+     * Unsubscribe the consumer from this vector's change notifications.
+     * 
+     * @param consumer - The consumer to unregister from the vector.
+     */
+    closeVector(consumer: IVectorConsumer<T>): void;
 }
 
 export interface IMatrixConsumer<T> {
@@ -261,10 +269,17 @@ export interface IMatrixReader<T> {
 /** Provides more efficient access to 2D data for matrix-aware consumers. */
 export interface IMatrixProducer<T> {
     /**
-     * Unsubscribes a consumer from this producer.
-     * @param consumer - The consumer to unregister from the Producer.
+     * Acquire a reader for this matrix's values and implicitly subscribe the consumer
+     * to value change notifications.
+     * 
+     * @param consumer - The consumer to be notified of matrix changes.
      */
-    removeMatrixConsumer(consumer: IMatrixConsumer<T>): void;
-
     openMatrix(consumer: IMatrixConsumer<T>): IMatrixReader<T>;
+    
+    /**
+     * Unsubscribe the consumer from this matrix's change notifications.
+     * 
+     * @param consumer - The consumer to unregister from the matrix.
+     */
+    closeMatrix(consumer: IMatrixConsumer<T>): void;
 }

--- a/packages/core/nano/src/types.ts
+++ b/packages/core/nano/src/types.ts
@@ -191,6 +191,11 @@ export interface IReader<T> {
      * @param property - The property of the Producer to read.
      */
     get<K extends keyof T>(property: K): T[K] | Pending<T[K]>;
+
+    /**
+     * A reference to the underlying producer that provides values for this reader.
+     */
+    readonly producer: IProducer<T>;
 }
 
 /**
@@ -225,6 +230,11 @@ export interface IVectorConsumer<T> {
 export interface IVectorReader<T> {
     readonly length: number;
     getItem(index: number): T;
+
+    /**
+     * A reference to the underlying vector producer that provides values for this reader.
+     */
+    readonly vectorProducer: IVectorProducer<T>;
 }
 
 /** Provides more efficient access to 1D data for vector-aware consumers. */
@@ -264,6 +274,11 @@ export interface IMatrixReader<T> {
     readonly rowCount: number;
     readonly colCount: number;
     getCell(row: number, col: number): T;
+
+    /**
+     * A reference to the underlying matrix producer that provides values for this reader.
+     */
+    readonly matrixProducer: IMatrixProducer<T>;
 }
 
 /** Provides more efficient access to 2D data for matrix-aware consumers. */

--- a/packages/core/nano/test/produce.spec.ts
+++ b/packages/core/nano/test/produce.spec.ts
@@ -1,17 +1,20 @@
 import "mocha";
 import { strict as assert } from "assert";
+
 import { produce } from "../src/produce";
 import { nullConsumer } from "./util";
 import { IProducer } from "../src/types";
 
 describe("produce()", () => {
     describe("object", () => {
-        it("supports open(), but not openVector()", () => {
+        it("supports open()/producer, but not openVector()/vectorProducer", () => {
             const p = produce({ a: 1 });
             assert.equal("openVector" in p, false);
+            assert.equal("vectorProducer" in p, false);
             const r = p.open(nullConsumer);
             assert.equal(r.get("a"), 1);
             assert.equal(r.get("b" as any), undefined);
+            r.producer.close(nullConsumer);
         });
 
         it("handles cycles", () => {
@@ -24,21 +27,24 @@ describe("produce()", () => {
             const childProducer = r.get("child") as unknown as IProducer<any>;
             const childReader = childProducer.open(nullConsumer);
             assert.equal(childReader.get("parent"), p);
+            p.close(nullConsumer);
         });
     });
 
     describe("array", () => {
-        it("supports open() and openVector()", () => {
+        it("supports both open()/producer and openVector()/vectorProducer", () => {
             const p = produce([0]);
             const r = p.open(nullConsumer);
             assert.equal(r.get("length"), 1);
             assert.equal(r.get("0" as any), 0);
             assert.equal(r.get("1" as any), undefined);
+            r.producer.close(nullConsumer);
 
             const v = p.openVector(nullConsumer);
             assert.equal(v.length, 1);
             assert.equal(v.getItem(0), 0);
             assert.equal(v.getItem(1), undefined);
+            v.vectorProducer.closeVector(nullConsumer);
         });
 
         it("handles cycles", () => {
@@ -51,6 +57,7 @@ describe("produce()", () => {
             const childProducer = r.getItem(0);
             const childReader = childProducer.open(nullConsumer);
             assert.equal(childReader.getItem(0), p);
+            p.closeVector(nullConsumer);
         });
     });
 });

--- a/packages/test/example/src/types.ts
+++ b/packages/test/example/src/types.ts
@@ -23,7 +23,7 @@ export class Context implements Producer {
 
     id = "context";
 
-    removeConsumer() { }
+    close() { }
 
     open() {
         return { get: (key: string) => this.fields[key] };
@@ -35,7 +35,7 @@ export class TimeProducer implements Producer {
 
     id = "Time";
 
-    removeConsumer() { }
+    close() { }
 
     open() {
         const time = Date.now();
@@ -125,7 +125,7 @@ export class MathProducer implements Producer {
 
     id = "Math";
 
-    removeConsumer() { }
+    close() { }
 
     open() {
         return {

--- a/packages/test/example/src/types.ts
+++ b/packages/test/example/src/types.ts
@@ -26,7 +26,11 @@ export class Context implements Producer {
     close() { }
 
     open() {
-        return { get: (key: string) => this.fields[key] };
+        const producer: Producer = this;
+        return { 
+            get: (key: string) => this.fields[key],
+            producer
+        };
     }
 }
 
@@ -39,8 +43,11 @@ export class TimeProducer implements Producer {
 
     open() {
         const time = Date.now();
-        const reader = { get: () => time };
-        return reader;
+        const producer: Producer = this;
+        return { 
+            get: () => time,
+            producer
+        };
     }
 }
 
@@ -128,6 +135,8 @@ export class MathProducer implements Producer {
     close() { }
 
     open() {
+        const producer: Producer = this;
+
         return {
             get: (property: string) => {
                 switch (property) {
@@ -136,6 +145,7 @@ export class MathProducer implements Producer {
                     default: return Math.PI; // a stupid default;
                 }
             },
+            producer
         };
     }
 }


### PR DESCRIPTION
Two changes:
1.  Rename `removeConsumer()` -> `close()` for symmetry with `open()` (and brevity)
2. IReader now surfaces a readonly reference to the underlying producer.

The motivation for the second change is to avoid the need to hold a references to both the reader and the producer (as described [here](https://github.com/microsoft/tiny-calc/issues/58#issuecomment-619052672)).

The two scenarios were:

1.  Holding a ref to the producer for `close()`
2.  Holding a ref to the producer to compare with the 'producer' field in change notifications.

This avoids the need to keep duplicate references be surfacing a producer reference via the reader:

```ts
reader.producer.close(/* consumer: */ this);
```