### PR TITLE
RowMajorMatrix benchmark

### DIFF
--- a/packages/core/micro/bench/index.ts
+++ b/packages/core/micro/bench/index.ts
@@ -10,4 +10,9 @@ import { run } from "hotloop";
         { "path": "./sheetlet/cached-10x10.ts" },
         { "path": "./sheetlet/recalc-10x10.ts" },
     ]);
+
+    await run([
+        { "path": "./matrix/rowmajor-256x256-read-baseline.ts" },
+        { "path": "./matrix/rowmajor-256x256-read.ts" },
+    ]);
 })();

--- a/packages/core/micro/bench/matrix/index.ts
+++ b/packages/core/micro/bench/matrix/index.ts
@@ -1,0 +1,38 @@
+import { benchmark } from "hotloop";
+import { IMatrixReader, IMatrixWriter } from "@tiny-calc/nano/src/types";
+import { consume } from "../util";
+
+export function sumBenchmark(name: string, reader: IMatrixReader<number>) {
+    const { rowCount, colCount } = reader;
+
+    benchmark(`Matrix (${name} ${rowCount}x${colCount}): sum row-wise`, () => {
+        let sum = 0;
+        
+        for (let row = 0; row < rowCount; row++) {
+            for (let col = 0; col < colCount; col++) {
+                sum += reader.getCell(row, col);
+            }
+        }
+
+        consume(sum);
+    });    
+}
+
+export function fill(
+    reader: IMatrixReader<number>,
+    writer: IMatrixWriter<number>,
+    rowStart = 0,
+    colStart = 0,
+    rowCount = reader.rowCount - rowStart,
+    colCount = reader.colCount - colStart,
+    value = (row: number, col: number) => row * rowCount + col
+) {
+    const rowEnd = rowStart + rowCount;
+    const colEnd = colStart + colCount;
+
+    for (let row = rowStart; row < rowEnd; row++) {
+        for (let col = colStart; col < colEnd; col++) {
+            writer.setCell(row, col, value(row, col) as any);
+        }
+    }
+}

--- a/packages/core/micro/bench/matrix/rowmajor-256x256-read-baseline.ts
+++ b/packages/core/micro/bench/matrix/rowmajor-256x256-read-baseline.ts
@@ -1,0 +1,32 @@
+import { IMatrixWriter, IMatrixReader } from "@tiny-calc/nano/src/types";
+import { fill, sumBenchmark } from ".";
+
+export class Array256x256 implements IMatrixWriter<number>, IMatrixReader<number> {
+    private readonly cells: number[] = new Array(this.rowCount * this.colCount).fill(0);
+
+    //#region IMatrixReader
+
+    public readonly matrixProducer = undefined as any;
+
+    public get rowCount() { return 256; }
+    public get colCount() { return 256; }
+
+    public getCell(row: number, col: number) {
+        return this.cells[(row << 8) + col];
+    }
+
+    //#endregion IMatrixReader
+
+    //#region IMatrixWriter
+
+    public setCell(row: number, col: number, value: number) {
+        this.cells[(row << 8) + col] = value;
+    }
+
+    //#endregion IMatrixWriter
+}
+
+const matrix = new Array256x256();
+
+fill(matrix, matrix);
+sumBenchmark("Baseline", matrix);

--- a/packages/core/micro/bench/matrix/rowmajor-256x256-read.ts
+++ b/packages/core/micro/bench/matrix/rowmajor-256x256-read.ts
@@ -1,0 +1,12 @@
+import { RowMajorMatrix, DenseVector } from "../../src";
+import { nullConsumer } from "../util";
+import { sumBenchmark, fill } from ".";
+
+const rows = new DenseVector();
+const cols = new DenseVector();
+const matrix = new RowMajorMatrix<number>(rows, cols);
+rows.splice(/* start: */ 0, /* deleteCount: */ 0, /* insertCount: */ 256);
+cols.splice(/* start: */ 0, /* deleteCount: */ 0, /* insertCount: */ 256);
+
+fill(matrix, matrix);
+sumBenchmark("RowMajor", matrix.openMatrix(nullConsumer));

--- a/packages/core/micro/bench/util.ts
+++ b/packages/core/micro/bench/util.ts
@@ -1,4 +1,11 @@
+import { IMatrixConsumer } from "@tiny-calc/nano";
 const process = require("process");
+
+export const nullConsumer: IMatrixConsumer<unknown> = {
+    rowsChanged() { },
+    colsChanged() { },
+    cellsChanged() { },
+}
 
 let count = 0;
 let cached: any;

--- a/packages/core/micro/src/matrix/dense.ts
+++ b/packages/core/micro/src/matrix/dense.ts
@@ -9,8 +9,7 @@ import { MatrixProducer } from "./producer";
  * A row/col-major agnostic base class 
  */
 export abstract class DenseMatrix<T> extends MatrixProducer<T> {
-    private readonly cells: T[] = [];
-
+    protected cells: T[] = [];
     protected abstract get majorCount(): number;
     protected abstract get stride(): number;
     

--- a/packages/core/micro/src/matrix/rowmajor.ts
+++ b/packages/core/micro/src/matrix/rowmajor.ts
@@ -10,6 +10,8 @@ export class RowMajorMatrix<T, TRow = unknown, TCol = unknown> extends DenseMatr
 
         this.rowReader = rows.openVector(this);
         this.colReader = cols.openVector(this);
+
+        this.cells = new Array(this.rowCount * this.colCount).fill(undefined);
     }
 
     //#region IMatrixReader


### PR DESCRIPTION
The fastest row-major matrix I know how to write is ~20% faster, but only when initialized zeros (node v12 x64).  If I initialize with 'undefined', the benchmarks are identical.