### PR TITLE
Types: Add Tuple<T, Length> type

### DIFF
--- a/packages/types/types/src/index.ts
+++ b/packages/types/types/src/index.ts
@@ -4,6 +4,8 @@
  */
 
 export { CompareFunction } from './compareFunction';
+export { Tuple } from "./tuple";
+
 export {
     IConsumer,
     IMapProducer,
@@ -15,6 +17,7 @@ export {
     IShapeWriter,
     IWriter
 } from './record';
+
 export {
     IVectorConsumer,
     IVectorProducer,
@@ -25,6 +28,7 @@ export {
     IVectorShapeWriter,
     IVectorWriter
 } from './vector';
+
 export {
     IMatrixConsumer,
     IMatrixProducer,
@@ -35,6 +39,7 @@ export {
     IMatrixShapeWriter,
     IMatrixWriter
 } from './matrix';
+
 export {
     ITreeShapeConsumer,
     ITreeShapeProducer,

--- a/packages/types/types/src/tuple.ts
+++ b/packages/types/types/src/tuple.ts
@@ -1,0 +1,12 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * A non-empty fixed-length readonly Array<T>.  Uses the type system to
+ * ensure that Tuples are initialized with an array of the specified `Length`.
+ */
+export type Tuple<T, Length extends number> = readonly [T, ...T[]] & {
+    readonly length: Length;
+};

--- a/packages/types/types/test/tuple.spec.ts
+++ b/packages/types/types/test/tuple.spec.ts
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import "mocha";
+import { strict as assert } from "assert";
+import { Tuple } from "../src";
+
+describe("Tuple", () => {
+    describe("construction", () => {
+        it("can construct Tuple<T, 1>", () => {
+            const t1: Tuple<number, 1> = [0];
+            assert.equal(Array.isArray(t1), true);
+        });
+
+        it("can construct Tuple<T, 2>", () => {
+            const t2: Tuple<number, 2> = [0, 1];
+            assert.equal(Array.isArray(t2), true);
+        });
+    });
+
+    it("is compatible with ReadonlyArray<T>", () => {
+        const tuple: Tuple<number, 3> = [1, 2, 3];
+        const array: ReadonlyArray<number> = tuple;
+
+        assert.equal(array.length, 3);
+        assert.equal(array[2], 3);
+        assert.equal(
+            array.reduce(
+                (accumulator, value) => value + accumulator,
+                0),
+            6);
+    });
+});


### PR DESCRIPTION
Adds a `Tuple<T, Length>` type that statically ensures that:
1.  Variables are initialized with arrays of the expected length.
2.  Arrays of type tuple never change length (i.e., they are 'readonly T[]')

For example, this will produce a compile time error:
```ts
const tuple: Tuple<number, 3> = [0, 1];   // error: too short
tuple.push(4);                            // error: length can not be changed
```