### PR TITLE
Vector/Matrix: Avoid collision w/'splice' (Fixes #84)

### DIFF
--- a/packages/core/micro/src/vector/dense.ts
+++ b/packages/core/micro/src/vector/dense.ts
@@ -30,7 +30,7 @@ export class DenseVector<T> extends VectorProducer<T> implements IVectorWriter<T
         this.invalidateItems(index, /* removedCount: */ 1, /* insertedCount: */ 1);
     }
 
-    public splice(start: number, deleteCount: number, insertCount: number, values?: Iterable<T>): void {
+    public resize(start: number, deleteCount: number, insertCount: number, values?: Iterable<T>): void {
         const inserted = toArray(values);
         inserted.length = insertCount;
 

--- a/packages/core/micro/test/matrix.spec.ts
+++ b/packages/core/micro/test/matrix.spec.ts
@@ -213,7 +213,7 @@ export class TestMatrix<T = any, TRow = never, TCol = never> implements IMatrixC
         this.log.push(`matrix.insertRows(${rowStart},${rowCount});    // rowCount: ${this.rowCount} -> ${this.rowCount + rowCount}, colCount: ${this.colCount}`);
 
         this.expected.insertRows(rowStart, rowCount);
-        this.rowWriter.splice(rowStart, /* deleteCount: */ 0, /* insertCount: */ rowCount);
+        this.rowWriter.resize(rowStart, /* deleteCount: */ 0, /* insertCount: */ rowCount);
 
         this.check();
     }
@@ -222,7 +222,7 @@ export class TestMatrix<T = any, TRow = never, TCol = never> implements IMatrixC
         this.log.push(`matrix.removeRows(${rowStart},${rowCount});    // rowCount: ${this.rowCount} -> ${this.rowCount - rowCount}, colCount: ${this.colCount}`);
 
         this.expected.removeRows(rowStart, rowCount);
-        this.rowWriter.splice(rowStart, /* deleteCount: */ rowCount, /* insertCount: */ 0);
+        this.rowWriter.resize(rowStart, /* deleteCount: */ rowCount, /* insertCount: */ 0);
 
         this.check();
     }
@@ -231,7 +231,7 @@ export class TestMatrix<T = any, TRow = never, TCol = never> implements IMatrixC
         this.log.push(`matrix.insertCols(${colStart},${colCount});    // colCount: ${this.colCount} -> ${this.colCount + colCount}, colCount: ${this.colCount}`);
 
         this.expected.insertCols(colStart, colCount);
-        this.colWriter.splice(colStart, /* deleteCount: */ 0, /* insertCount: */ colCount);
+        this.colWriter.resize(colStart, /* deleteCount: */ 0, /* insertCount: */ colCount);
 
         this.check();
     }
@@ -240,7 +240,7 @@ export class TestMatrix<T = any, TRow = never, TCol = never> implements IMatrixC
         this.log.push(`matrix.removeCols(${colStart},${colCount});    // colCount: ${this.colCount} -> ${this.colCount - colCount}, colCount: ${this.colCount}`);
 
         this.expected.removeCols(colStart, colCount);
-        this.colWriter.splice(colStart, /* deleteCount: */ colCount, /* insertCount: */ 0);
+        this.colWriter.resize(colStart, /* deleteCount: */ colCount, /* insertCount: */ 0);
 
         this.check();
     }

--- a/packages/core/micro/test/vector.spec.ts
+++ b/packages/core/micro/test/vector.spec.ts
@@ -26,7 +26,7 @@ export class TestVector<T> implements IVectorConsumer<T> {
 
     public splice(start: number, deletedCount: number, ...items: T[]): void {
         this.expected.splice(start, deletedCount, ...items);
-        this.writer.splice(start, deletedCount, items.length);
+        this.writer.resize(start, deletedCount, items.length);
         for (const value of items) {
             this.writer.setItem(start++, value);
         }

--- a/packages/types/types/src/matrix.ts
+++ b/packages/types/types/src/matrix.ts
@@ -42,10 +42,14 @@ export interface IMatrixShapeReader {
     readonly matrixProducer?: IMatrixShapeProducer;
 }
 
-/** Capability to write cells in a matrix. */
+/**
+ * Capability to adjust the matrix's dimensions by inserting and/or removing rows &
+ * columns.  Use 'IMatrixWriter' to assign values to the inserted cells.  (The initial
+ * value of newly inserted cells is implementation specific.)
+ */
 export interface IMatrixShapeWriter {
-    spliceRows(rowStart: number, deleteCount: number, insertCount: number): void;
-    spliceCols(colStart: number, deleteCount: number, insertCount: number): void;
+    resizeRows(rowStart: number, deleteCount: number, insertCount: number): void;
+    resizeCols(colStart: number, deleteCount: number, insertCount: number): void;
 }
 
 /** An observable 2D numerically indexed collection. */

--- a/packages/types/types/src/vector.ts
+++ b/packages/types/types/src/vector.ts
@@ -32,9 +32,13 @@ export interface IVectorShapeReader {
     readonly vectorProducer?: IVectorShapeProducer;
 }
 
-/** Capability to insert, replace, and remove items in a vector. */
+/**
+ * Capability to adjust the vector's length by inserting and/or removing items.  Use
+ * 'IVectorWriter' to assign values to the inserted items.  (The initial value of newly
+ * inserted items is implementation specific.)
+ */
 export interface IVectorShapeWriter {
-    splice(start: number, deleteCount: number, insertCount: number): void;
+    resize(start: number, deleteCount: number, insertCount: number): void;
 }
 
 export interface IVectorShapeConsumer {


### PR DESCRIPTION
Renames 'splice()' to avoid a pitfall found while implementing an 'ObservableArray' that extends 'Array' and implements IVectorShapeWriter.  (Described in issue #84).
